### PR TITLE
Improve Railway deployment readiness

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -77,7 +77,7 @@ jobs:
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
-          npx railway up --service web-app --environment ${{ steps.env-map.outputs.env }} --yes
+          npx railway up --service web-app --environment ${{ steps.env-map.outputs.env }} --yes --ci
 
       - name: Health check
         run: |

--- a/README.md
+++ b/README.md
@@ -35,28 +35,25 @@ npm run dev
 
 Environment variables must be set before running locally. See [`.env.example`](.env.example).
 
-## Deployment
+## Deployment & Environments
 
-This repo deploys as the `web-app` service inside the Railway project **`blackroad-web`**.
+This repository contains the BlackRoad OS web UI. It deploys to the Railway project **`blackroad-web`** as the `web-app` service.
 
-- **Environments → URLs**
-  - `dev`: Railway dev URL (or `https://dev.blackroad.systems` when fronted by Cloudflare)
+- **Environment → URL**
+  - `dev`: Railway dev URL (or `https://dev.blackroad.systems`)
   - `staging`: `https://staging.blackroad.systems`
   - `prod`: `https://blackroad.systems`
 
-- **Core API endpoints**
-  - `dev`: core dev Railway URL
-  - `staging`: `https://staging.core.blackroad.systems`
-  - `prod`: `https://core.blackroad.systems`
-
-- **Environment variables expected**
-  - `NODE_ENV` (`development` | `staging` | `production`)
-  - `CORE_API_URL` / `PUBLIC_APP_URL` (server-side)
-  - `NEXT_PUBLIC_CORE_API_URL` / `NEXT_PUBLIC_APP_URL` (client-exposed)
+- **Required environment variables**
+  - `NODE_ENV`
+  - `CORE_API_URL`
+  - `PUBLIC_APP_URL`
+  - `NEXT_PUBLIC_CORE_API_URL`
+  - `NEXT_PUBLIC_APP_URL`
 
 - **Commands**
   - Install: `npm install`
   - Build: `npm run build`
   - Start: `npm run start`
 
-Deployments are automated via `.github/workflows/deploy-web.yml` and perform a post-deploy `/health` check against the environment URL.
+Deployment automation lives in `.github/workflows/deploy-web.yml` and performs post-deploy health checks against the environment URL.

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -5,6 +5,6 @@ export async function GET() {
   return NextResponse.json({
     status: 'ok',
     timestamp: new Date().toISOString(),
-    environment: appConfig.nodeEnv
+    environment: appConfig.env
   });
 }

--- a/app/version/route.ts
+++ b/app/version/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { appConfig } from '@/config';
+import packageJson from '../../package.json';
+
+const serviceName = 'web-app';
+
+export async function GET() {
+  const commitSha =
+    process.env.RAILWAY_GIT_COMMIT_SHA ||
+    process.env.VERCEL_GIT_COMMIT_SHA ||
+    process.env.GITHUB_SHA ||
+    '';
+
+  const buildTime = process.env.RAILWAY_BUILD_TIMESTAMP || process.env.BUILD_TIME || '';
+
+  return NextResponse.json({
+    service: serviceName,
+    appVersion: packageJson.version,
+    commit: commitSha,
+    buildTime: buildTime,
+    environment: appConfig.env
+  });
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -H 0.0.0.0 -p ${PORT:-3000}",
     "lint": "next lint"
   },
   "dependencies": {

--- a/railway.json
+++ b/railway.json
@@ -4,7 +4,7 @@
   "services": [
     {
       "name": "web-app",
-      "buildCommand": "npm run build",
+      "buildCommand": "npm ci && npm run build",
       "startCommand": "npm run start",
       "port": 3000,
       "envVariables": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,33 +1,29 @@
 export type NodeEnvironment = 'development' | 'staging' | 'production';
 
-const isServer = typeof window === 'undefined';
-
-function requireEnv(key: string): string {
-  const value = process.env[key];
-
-  if (!value) {
-    if (isServer) {
-      throw new Error(`Missing required environment variable: ${key}`);
-    }
-
-    return '';
-  }
-
-  return value;
-}
-
+const allowedEnvironments: NodeEnvironment[] = ['development', 'staging', 'production'];
 const rawNodeEnv = process.env.NODE_ENV ?? 'development';
-const nodeEnv: NodeEnvironment = ['development', 'staging', 'production'].includes(rawNodeEnv)
+const env: NodeEnvironment = allowedEnvironments.includes(rawNodeEnv as NodeEnvironment)
   ? (rawNodeEnv as NodeEnvironment)
   : 'development';
 
+function getEnv(key: string): string {
+  const value = process.env[key];
+
+  if (!value && env !== 'development') {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+
+  return value ?? '';
+}
+
 export const appConfig = {
-  nodeEnv,
-  isDevelopment: nodeEnv === 'development',
-  coreApiUrl: requireEnv('CORE_API_URL'),
-  appUrl: requireEnv('PUBLIC_APP_URL'),
-  publicCoreApiUrl: requireEnv('NEXT_PUBLIC_CORE_API_URL'),
-  publicAppUrl: requireEnv('NEXT_PUBLIC_APP_URL')
+  env,
+  nodeEnv: env,
+  isDevelopment: env === 'development',
+  coreApiUrl: getEnv('CORE_API_URL'),
+  appUrl: getEnv('PUBLIC_APP_URL'),
+  publicCoreApiUrl: getEnv('NEXT_PUBLIC_CORE_API_URL'),
+  publicAppUrl: getEnv('NEXT_PUBLIC_APP_URL')
 };
 
 export type AppConfig = typeof appConfig;

--- a/src/lib/telemetry.ts
+++ b/src/lib/telemetry.ts
@@ -1,7 +1,9 @@
+import { appConfig } from '@/config';
+
 type TelemetryPayload = Record<string, unknown>;
 
 export function logEvent(name: string, payload: TelemetryPayload = {}) {
-  if (process.env.NODE_ENV === 'development') {
+  if (appConfig.isDevelopment) {
     // eslint-disable-next-line no-console
     console.debug(`[telemetry] ${name}`, payload);
   }


### PR DESCRIPTION
## Summary
- centralize environment validation and add a /version endpoint exposing build metadata
- ensure start/build commands align with Railway, updating railway.json and deployment workflow
- document deployment environments and required variables in the README

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e329d6454832981470ec6c1347069)