### PR TITLE
Improve health widget timestamp display

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -41,14 +41,14 @@ function HealthWidget() {
 
         setHealth({
           status: data.ok ? 'online' : 'offline',
-          checkedAt: new Date().toLocaleTimeString(),
+          checkedAt: data.ts ? new Date(data.ts).toLocaleString() : new Date().toLocaleString(),
           message: data.ok ? undefined : 'Service reported an issue.'
         });
       } catch (error) {
         if (!isMounted) return;
         setHealth({
           status: 'offline',
-          checkedAt: new Date().toLocaleTimeString(),
+          checkedAt: new Date().toLocaleString(),
           message: error instanceof Error ? error.message : 'Unable to reach status endpoint.'
         });
       }


### PR DESCRIPTION
## Summary
- display health check timestamp using server-provided time when available for clearer diagnostics

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fd41f87c88329a774cd0721188f5c)