### PR TITLE
Add OS metadata APIs and homepage status display

### DIFF
--- a/app/api/info/route.ts
+++ b/app/api/info/route.ts
@@ -1,12 +1,18 @@
 import { NextResponse } from 'next/server';
+import packageJson from '../../../package.json';
+import { appConfig } from '@/config';
 import { serviceConfig } from '@/config/serviceConfig';
 
 export async function GET() {
   return NextResponse.json({
-    name: serviceConfig.SERVICE_NAME,
-    id: serviceConfig.SERVICE_ID,
-    baseUrl: serviceConfig.SERVICE_BASE_URL,
-    osRoot: serviceConfig.OS_ROOT,
-    ts: new Date().toISOString()
+    service: serviceConfig.SERVICE_ID,
+    version: packageJson.version,
+    environment: appConfig.env,
+    links: {
+      core: 'https://core.blackroad.systems/health',
+      operator: 'https://operator.blackroad.systems/health',
+      console: 'https://console.blackroad.systems',
+      docs: 'https://docs.blackroad.systems'
+    }
   });
 }

--- a/app/api/status/route.ts
+++ b/app/api/status/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from 'next/server';
+import { osServices } from '@/config/services';
+
+const STATUS_TIMEOUT_MS = 4000;
+
+async function checkServiceHealth(service: (typeof osServices)[number]) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), STATUS_TIMEOUT_MS);
+
+  let status: 'up' | 'down' = 'down';
+
+  try {
+    const response = await fetch(service.healthUrl, {
+      cache: 'no-store',
+      signal: controller.signal
+    });
+
+    status = response.ok ? 'up' : 'down';
+  } catch (error) {
+    // swallow error and mark as down
+    status = 'down';
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  return {
+    id: service.id,
+    status,
+    lastCheckedAt: new Date().toISOString()
+  };
+}
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const results = await Promise.all(osServices.map((service) => checkServiceHealth(service)));
+
+  return NextResponse.json({
+    services: results
+  });
+}

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -120,6 +120,32 @@
   gap: 0.35rem;
 }
 
+.serviceStatusList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.serviceRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.85rem 0.95rem;
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  gap: 0.75rem;
+}
+
+.serviceCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
 .statusRow {
   display: flex;
   align-items: center;

--- a/app/version/route.ts
+++ b/app/version/route.ts
@@ -1,25 +1,11 @@
 import { NextResponse } from 'next/server';
 import packageJson from '../../package.json';
-import { appConfig } from '@/config';
 import { serviceConfig } from '@/config/serviceConfig';
 
 function collectVersionPayload() {
-  const commitSha =
-    process.env.RAILWAY_GIT_COMMIT_SHA ||
-    process.env.VERCEL_GIT_COMMIT_SHA ||
-    process.env.GITHUB_SHA ||
-    '';
-
-  const buildTime = process.env.RAILWAY_BUILD_TIMESTAMP || process.env.BUILD_TIME || '';
-
   return {
     service: serviceConfig.SERVICE_ID,
-    name: serviceConfig.SERVICE_NAME,
-    appVersion: packageJson.version,
-    commit: commitSha,
-    buildTime,
-    environment: appConfig.env,
-    ts: new Date().toISOString()
+    version: packageJson.version
   };
 }
 

--- a/src/config/services.ts
+++ b/src/config/services.ts
@@ -1,0 +1,7 @@
+export const osServices = [
+  { id: 'core', name: 'Core Service', healthUrl: 'https://core.blackroad.systems/health' },
+  { id: 'operator', name: 'Operator Service', healthUrl: 'https://operator.blackroad.systems/health' },
+  { id: 'web', name: 'Web Frontend', healthUrl: 'https://blackroad.systems/api/health' },
+  { id: 'prism-console', name: 'Prism Console', healthUrl: 'https://console.blackroad.systems/api/health' },
+  { id: 'docs', name: 'Docs', healthUrl: 'https://docs.blackroad.systems/api/health' }
+];


### PR DESCRIPTION
## Summary
- add a shared OS services registry aligned with the Prism Console shape
- expose public info, version, and status API routes for the web service
- surface a homepage system status list with refreshed styling

## Testing
- npm run lint *(fails: repository package.json is not valid JSON and prevents npm from running)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920c7ae1fc083298bfe4a4e694bbc98)