### PR TITLE
Build marketing site layout with status views

### DIFF
--- a/app/os/page.module.css
+++ b/app/os/page.module.css
@@ -1,0 +1,52 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.subtitle {
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.sectionHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.card h3 {
+  margin: 0;
+}

--- a/app/os/page.tsx
+++ b/app/os/page.tsx
@@ -1,0 +1,45 @@
+import styles from './page.module.css';
+
+const layers = [
+  { title: 'Core', description: 'Ledger engine and internal APIs that anchor every transaction.' },
+  { title: 'Operator', description: 'Job runners, schedulers, and workers that keep services on track.' },
+  { title: 'Web', description: 'Public web surfaces, marketing, and live status endpoints.' },
+  { title: 'Prism Console', description: 'Operational control plane for operators and administrators.' },
+  { title: 'Docs', description: 'Integration guides, playbooks, and knowledge for teams.' }
+];
+
+export default function OsPage() {
+  return (
+    <div className={styles.page}>
+      <section className={`panel ${styles.hero}`}>
+        <p className="muted">Architecture</p>
+        <h1>BlackRoad OS Layers</h1>
+        <p className={styles.subtitle}>
+          The OS is composed of coordinated layers that share a ledger-first foundation and expose
+          predictable interfaces for builders, operators, and partners.
+        </p>
+      </section>
+
+      <section className={`panel ${styles.section}`}>
+        <div className={styles.sectionHeader}>
+          <div>
+            <p className="muted">Layered system</p>
+            <h2>How it fits together</h2>
+            <p className={styles.subtitle}>
+              Each component has a clear responsibility so teams can compose resilient automation and
+              ship confidently.
+            </p>
+          </div>
+        </div>
+        <div className={styles.cardGrid}>
+          {layers.map((layer) => (
+            <div key={layer.title} className={styles.card}>
+              <h3>{layer.title}</h3>
+              <p className="muted">{layer.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -7,35 +7,21 @@
 .hero {
   display: flex;
   flex-direction: column;
-  gap: 0.85rem;
+  gap: 0.75rem;
 }
 
 .subtitle {
   color: var(--muted);
-  font-size: 1.1rem;
+  font-size: 1.05rem;
   line-height: 1.6;
   margin: 0;
-}
-
-.metaRow {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.75rem;
-  margin-top: 0.75rem;
-}
-
-.metaItem {
-  background: rgba(255, 255, 255, 0.02);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 0.9rem;
 }
 
 .ctaRow {
   display: flex;
   gap: 0.75rem;
   flex-wrap: wrap;
-  margin-top: 0.25rem;
+  margin-top: 0.35rem;
 }
 
 .ctaButton,
@@ -67,99 +53,46 @@
   box-shadow: 0 12px 30px rgba(0, 0, 0, 0.25);
 }
 
-.linkList {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+.section {
   display: flex;
   flex-direction: column;
-  gap: 0.65rem;
+  gap: 1rem;
 }
 
-.linkRow {
+.sectionHeader {
   display: flex;
-  align-items: center;
   justify-content: space-between;
-  padding: 0.85rem 0.95rem;
+  align-items: flex-start;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.card {
   background: rgba(255, 255, 255, 0.02);
   border: 1px solid var(--border);
-  border-radius: 12px;
-  gap: 0.75rem;
-}
-
-.linkAnchor {
-  font-size: 1.05rem;
-  font-weight: 700;
-}
-
-.externalHint {
-  color: var(--muted);
-}
-
-.metadataGrid {
-  display: flex;
-  flex-direction: column;
-  gap: 0.6rem;
-}
-
-.badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  background: rgba(114, 228, 162, 0.12);
-  border: 1px solid rgba(114, 228, 162, 0.35);
-  color: var(--accent);
-  padding: 0.45rem 0.85rem;
-  border-radius: 12px;
-  font-weight: 600;
-}
-
-.statusWidget {
+  border-radius: 14px;
+  padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
 }
 
-.statusRow {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.statusPill {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 90px;
-  padding: 0.45rem 0.75rem;
-  border-radius: 999px;
-  font-weight: 800;
-  letter-spacing: 0.5px;
-  border: 1px solid var(--border);
-}
-
-.statusMeta {
-  color: var(--muted);
-  font-size: 0.95rem;
-}
-
-.statusMessage {
+.card h3 {
   margin: 0;
-  color: var(--muted);
 }
 
-.loading {
-  background: rgba(255, 255, 255, 0.06);
-}
+@media (max-width: 640px) {
+  .hero {
+    padding: 1.25rem;
+  }
 
-.online {
-  background: rgba(114, 228, 162, 0.16);
-  color: var(--accent);
-  border-color: rgba(114, 228, 162, 0.4);
-}
-
-.offline {
-  background: rgba(255, 99, 99, 0.16);
-  color: #ff8f8f;
-  border-color: rgba(255, 99, 99, 0.4);
+  .section {
+    padding: 1.25rem;
+  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,159 +1,77 @@
-'use client';
-
-import { useEffect, useMemo, useState } from 'react';
 import styles from './page.module.css';
-import { InfoCard } from '@/components/primitives/InfoCard';
-import { serviceConfig } from '@/config/serviceConfig';
+import { StatusWidget } from '@/components/status/StatusWidget';
 
-type HealthStatus = 'loading' | 'online' | 'offline';
+const consoleUrl = process.env.NEXT_PUBLIC_CONSOLE_URL || 'https://console.blackroad.systems';
+const docsUrl = process.env.NEXT_PUBLIC_DOCS_URL || 'https://docs.blackroad.systems';
 
-interface HealthState {
-  status: HealthStatus;
-  checkedAt?: string;
-  message?: string;
-}
-
-const defaultHealth: HealthState = {
-  status: 'loading'
-};
-
-const fallbackConsoleUrl = process.env.NEXT_PUBLIC_CONSOLE_URL || 'https://console.blackroad.systems';
-const fallbackDocsUrl = process.env.NEXT_PUBLIC_DOCS_URL || 'https://docs.blackroad.systems';
-const fallbackCoreApiUrl = process.env.NEXT_PUBLIC_CORE_API_URL || 'https://core.blackroad.systems';
-const publicApiUrl = process.env.NEXT_PUBLIC_PUBLIC_API_URL || 'https://api.blackroad.systems';
-
-function HealthWidget() {
-  const [health, setHealth] = useState<HealthState>(defaultHealth);
-
-  useEffect(() => {
-    let isMounted = true;
-
-    async function checkHealth() {
-      setHealth({ status: 'loading' });
-
-      try {
-        const response = await fetch('/api/health');
-        if (!response.ok) {
-          throw new Error(`Request failed with status ${response.status}`);
-        }
-        const data = await response.json();
-        if (!isMounted) return;
-
-        setHealth({
-          status: data.ok ? 'online' : 'offline',
-          checkedAt: data.ts ? new Date(data.ts).toLocaleString() : new Date().toLocaleString(),
-          message: data.ok ? undefined : 'Service reported an issue.'
-        });
-      } catch (error) {
-        if (!isMounted) return;
-        setHealth({
-          status: 'offline',
-          checkedAt: new Date().toLocaleString(),
-          message: error instanceof Error ? error.message : 'Unable to reach status endpoint.'
-        });
-      }
-    }
-
-    checkHealth();
-    const interval = setInterval(checkHealth, 15000);
-
-    return () => {
-      isMounted = false;
-      clearInterval(interval);
-    };
-  }, []);
-
-  const statusLabel = useMemo(() => {
-    if (health.status === 'loading') return 'Checking...';
-    return health.status === 'online' ? 'ONLINE' : 'OFFLINE';
-  }, [health.status]);
-
-  return (
-    <div className={styles.statusWidget}>
-      <div className={styles.statusRow}>
-        <span className={`${styles.statusPill} ${styles[health.status]}`}>{statusLabel}</span>
-        {health.checkedAt ? <span className={styles.statusMeta}>Last checked: {health.checkedAt}</span> : null}
-      </div>
-      {health.message ? <p className={styles.statusMessage}>{health.message}</p> : null}
-    </div>
-  );
-}
+const pillars = [
+  {
+    title: 'Orchestration',
+    description: 'Coordinated workflows for agents, services, and ledger-aware actions.'
+  },
+  {
+    title: 'Observability',
+    description: 'Built-in telemetry, health, and audit layers to keep operators in control.'
+  },
+  {
+    title: 'Compliance',
+    description: 'Policy-driven safeguards that keep the platform aligned with governance.'
+  }
+];
 
 export default function HomePage() {
-  const systemLinks = [
-    { label: 'Prism Console', href: fallbackConsoleUrl, description: 'Manage agents, deployments, and OS resources.' },
-    { label: 'Docs', href: fallbackDocsUrl, description: 'Developer and operator guides for BlackRoad OS.' },
-    { label: 'Core API', href: fallbackCoreApiUrl, description: 'Primary API surface for orchestrating the OS.' },
-    { label: 'Public API', href: publicApiUrl, description: 'External integrations and public endpoints.' }
-  ];
-
   return (
     <div className={styles.page}>
       <section className={`panel ${styles.hero}`}>
         <p className="muted">BlackRoad Operating System</p>
         <h1>BlackRoad OS</h1>
         <p className={styles.subtitle}>
-          Distributed operating system for agents, finance, and quantum-native infrastructure.
+          The operations layer for secure, ledger-native automation. Build, observe, and control the
+          BlackRoad stack from a single, trusted interface.
         </p>
-        <div className={styles.metaRow}>
-          <div className={styles.metaItem}>
-            <span className="muted">Service ID</span>
-            <strong>{serviceConfig.SERVICE_ID}</strong>
-          </div>
-          <div className={styles.metaItem}>
-            <span className="muted">Service Name</span>
-            <strong>{serviceConfig.SERVICE_NAME}</strong>
-          </div>
-          <div className={styles.metaItem}>
-            <span className="muted">Base URL</span>
-            <strong>{serviceConfig.SERVICE_BASE_URL}</strong>
-          </div>
-        </div>
         <div className={styles.ctaRow}>
-          <a className={styles.ctaButton} href={fallbackConsoleUrl} target="_blank" rel="noreferrer">
-            Open Prism Console
+          <a className={styles.ctaButton} href={consoleUrl} target="_blank" rel="noreferrer">
+            View Console
           </a>
-          <a className={styles.ctaButtonSecondary} href={fallbackDocsUrl} target="_blank" rel="noreferrer">
-            View Documentation
+          <a className={styles.ctaButtonSecondary} href={docsUrl} target="_blank" rel="noreferrer">
+            Read Docs
           </a>
         </div>
       </section>
 
-      <div className="grid">
-        <InfoCard title="System Links" description="Entrypoints into the BlackRoad ecosystem.">
-          <ul className={styles.linkList}>
-            {systemLinks.map((link) => (
-              <li key={link.href} className={styles.linkRow}>
-                <div>
-                  <a className={styles.linkAnchor} href={link.href} target="_blank" rel="noreferrer">
-                    {link.label}
-                  </a>
-                  <p className="muted">{link.description}</p>
-                </div>
-                <span className={styles.externalHint}>↗</span>
-              </li>
-            ))}
-          </ul>
-        </InfoCard>
-
-        <InfoCard
-          title="Service Metadata"
-          description="Static configuration exported for consumers and diagnostics."
-        >
-          <div className={styles.metadataGrid}>
-            <div className={styles.badge}>OS Root: {serviceConfig.OS_ROOT}</div>
-            <div className={styles.badge}>Base URL: {serviceConfig.SERVICE_BASE_URL}</div>
-            <div className={styles.badge}>Service: {serviceConfig.SERVICE_NAME}</div>
+      <section className={`panel ${styles.section}`}>
+        <div className={styles.sectionHeader}>
+          <div>
+            <p className="muted">Platform overview</p>
+            <h2>What is BlackRoad OS?</h2>
+            <p className={styles.subtitle}>
+              A cohesive runtime that spans the core ledger, operator services, web interfaces, and
+              console workflows.
+            </p>
           </div>
-        </InfoCard>
+        </div>
+        <div className={styles.cardGrid}>
+          {pillars.map((pillar) => (
+            <div key={pillar.title} className={styles.card}>
+              <h3>{pillar.title}</h3>
+              <p className="muted">{pillar.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
 
-        <InfoCard
-          title="Status"
-          description="Live view powered by the /api/health endpoint."
-        >
-          <HealthWidget />
-        </InfoCard>
-      </div>
+      <section className={`panel ${styles.section}`}>
+        <div className={styles.sectionHeader}>
+          <div>
+            <p className="muted">Live telemetry</p>
+            <h2>System Snapshot</h2>
+            <p className={styles.subtitle}>
+              Quick glance at the public-facing services powering BlackRoad OS.
+            </p>
+          </div>
+        </div>
+        <StatusWidget />
+      </section>
     </div>
   );
 }

--- a/app/stack/page.module.css
+++ b/app/stack/page.module.css
@@ -1,0 +1,44 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.subtitle {
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cardGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.card h3 {
+  margin: 0;
+}

--- a/app/stack/page.tsx
+++ b/app/stack/page.tsx
@@ -1,0 +1,45 @@
+import styles from './page.module.css';
+
+const products = [
+  {
+    name: 'RoadChain',
+    description: 'Distributed ledger backbone that secures contracts, balances, and system actions.'
+  },
+  {
+    name: 'Prism Console',
+    description: 'Operational cockpit for configuring services, reviewing logs, and responding fast.'
+  },
+  {
+    name: 'Lucidia',
+    description: 'Intelligence layer for correlating signals across infrastructure and agents.'
+  },
+  {
+    name: 'Agents',
+    description: 'Specialized workers that execute, reconcile, and report across the BlackRoad stack.'
+  }
+];
+
+export default function StackPage() {
+  return (
+    <div className={styles.page}>
+      <section className={`panel ${styles.hero}`}>
+        <p className="muted">Products</p>
+        <h1>The BlackRoad Stack</h1>
+        <p className={styles.subtitle}>
+          Core offerings that combine ledger-grade safety with responsive operator controls.
+        </p>
+      </section>
+
+      <section className={`panel ${styles.section}`}>
+        <div className={styles.cardGrid}>
+          {products.map((product) => (
+            <div key={product.name} className={styles.card}>
+              <h3>{product.name}</h3>
+              <p className="muted">{product.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/status/page.module.css
+++ b/app/status/page.module.css
@@ -1,0 +1,24 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.subtitle {
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -1,0 +1,21 @@
+import styles from './page.module.css';
+import { StatusWidget } from '@/components/status/StatusWidget';
+
+export default function StatusPage() {
+  return (
+    <div className={styles.page}>
+      <section className={`panel ${styles.hero}`}>
+        <p className="muted">Live status</p>
+        <h1>BlackRoad OS Status</h1>
+        <p className={styles.subtitle}>
+          Real-time visibility into public-facing services. Data is pulled from the status endpoint
+          when available, with automatic fallback to core health.
+        </p>
+      </section>
+
+      <section className={`panel ${styles.section}`}>
+        <StatusWidget showServices />
+      </section>
+    </div>
+  );
+}

--- a/src/components/layout/Footer.module.css
+++ b/src/components/layout/Footer.module.css
@@ -1,17 +1,21 @@
 .footer {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   padding: 1.75rem 1.5rem 2.5rem;
   max-width: 960px;
   margin: 0 auto;
   color: var(--muted);
   font-size: 0.95rem;
+  gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .meta {
   display: flex;
   gap: 0.75rem;
   align-items: center;
+  flex-wrap: wrap;
 }
 
 .label {
@@ -25,4 +29,19 @@
   color: var(--accent);
   padding: 0.2rem 0.65rem;
   border-radius: 999px;
+}
+
+.login {
+  color: var(--text);
+  font-weight: 700;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.5rem 0.9rem;
+  background: rgba(255, 255, 255, 0.03);
+  transition: background 150ms ease, transform 150ms ease;
+}
+
+.login:hover {
+  background: rgba(114, 228, 162, 0.12);
+  transform: translateY(-1px);
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -4,12 +4,18 @@ export function Footer() {
   return (
     <footer className={styles.footer}>
       <div className={styles.meta}>
-        <span className={styles.label}>BlackRoad OS web</span>
-        <span className="muted">Railway & Cloudflare ready</span>
+        <span className={styles.label}>&copy; {new Date().getFullYear()} BlackRoad OS</span>
+        <span className="muted">Operational intelligence for modern systems.</span>
       </div>
       <div className={styles.meta}>
-        <span className="muted">Status:</span>
-        <span className={styles.badge}>alpha</span>
+        <a
+          className={styles.login}
+          href="https://console.blackroad.systems"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Operator Login
+        </a>
       </div>
     </footer>
   );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,72 +2,38 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { appConfig } from '@/config';
 import styles from './Header.module.css';
 
-const nav = [
+const navItems = [
   { href: '/', label: 'Home', external: false },
-  {
-    href: appConfig.nextPublicConsoleUrl || '/console',
-    label: 'Console',
-    external: !!appConfig.nextPublicConsoleUrl?.startsWith('http')
-type NavItem = {
-  href: string;
-  label: string;
-  isExternal: boolean;
-};
-
-const nav: NavItem[] = [
-  { href: '/', label: 'Home', isExternal: false },
-  {
-    href: appConfig.nextPublicConsoleUrl || '/console',
-    label: 'Console',
-    isExternal: !!(appConfig.nextPublicConsoleUrl && appConfig.nextPublicConsoleUrl.startsWith('http'))
-  },
-  {
-    href: appConfig.nextPublicDocsUrl || '/docs',
-    label: 'Docs',
-    external: !!appConfig.nextPublicDocsUrl?.startsWith('http')
-    isExternal: !!(appConfig.nextPublicDocsUrl && appConfig.nextPublicDocsUrl.startsWith('http'))
-  }
+  { href: '/os', label: 'OS', external: false },
+  { href: '/stack', label: 'Stack', external: false },
+  { href: '/status', label: 'Status', external: false },
+  { href: 'https://docs.blackroad.systems', label: 'Docs', external: true }
 ];
 
 export function Header() {
   const pathname = usePathname();
+
   return (
     <header className={styles.header}>
       <div className={styles.logo}>BlackRoad OS</div>
       <nav className={styles.nav}>
-        {nav.map((item) => {
-          if (item.external) {
-          // For external URLs, use a regular anchor tag
-          if (item.isExternal) {
-            return (
-              <a
-                key={item.href}
-                href={item.href}
-                target="_blank"
-                rel="noreferrer"
-              >
-                {item.label}
-              </a>
-            );
-          }
-          
-          // For internal routes, use Next.js Link
-          // Type assertion needed because external URLs can't be validated at compile time
-          return (
+        {navItems.map((item) =>
+          item.external ? (
+            <a key={item.href} href={item.href} target="_blank" rel="noreferrer">
+              {item.label}
+            </a>
+          ) : (
             <Link
               key={item.href}
-              className={pathname === item.href ? styles.active : undefined}
-              // @ts-expect-error - Internal route paths are valid but typed routes don't recognize fallback values
               href={item.href}
-              href={item.href as any}
+              className={pathname === item.href ? styles.active : undefined}
             >
               {item.label}
             </Link>
-          );
-        })}
+          )
+        )}
       </nav>
     </header>
   );

--- a/src/components/status/StatusWidget.module.css
+++ b/src/components/status/StatusWidget.module.css
@@ -1,0 +1,99 @@
+.widget {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.headline {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.error {
+  margin: 0;
+  color: #ff8f8f;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 90px;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 800;
+  letter-spacing: 0.5px;
+  border: 1px solid var(--border);
+}
+
+.meta {
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.loading {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.online {
+  background: rgba(114, 228, 162, 0.16);
+  color: var(--accent);
+  border-color: rgba(114, 228, 162, 0.4);
+}
+
+.offline {
+  background: rgba(255, 99, 99, 0.16);
+  color: #ff8f8f;
+  border-color: rgba(255, 99, 99, 0.4);
+}
+
+.serviceGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.8rem;
+}
+
+.serviceCard {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.85rem;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.serviceHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.serviceName {
+  font-weight: 700;
+}
+
+.servicePill {
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  font-size: 0.85rem;
+}
+
+.serviceMeta {
+  margin: 0.4rem 0 0.25rem 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.serviceMessage {
+  margin: 0;
+  color: var(--text);
+  opacity: 0.9;
+}

--- a/src/components/status/StatusWidget.tsx
+++ b/src/components/status/StatusWidget.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useStatusData } from './useStatusData';
+import styles from './StatusWidget.module.css';
+
+interface StatusWidgetProps {
+  showServices?: boolean;
+}
+
+export function StatusWidget({ showServices = false }: StatusWidgetProps) {
+  const { data, loading, error } = useStatusData();
+
+  const allUp = useMemo(() => {
+    if (!data) return false;
+    return data.ok && data.services.every((service) => service.status === 'UP');
+  }, [data]);
+
+  const headline = useMemo(() => {
+    if (loading) return 'Checking live system status...';
+    if (error) return 'Unable to fetch status right now.';
+    return allUp ? 'All systems nominal' : 'Some services down';
+  }, [allUp, error, loading]);
+
+  const lastChecked = useMemo(() => {
+    const timestamp = data?.checkedAt ?? data?.services?.[0]?.lastChecked;
+    return timestamp ? new Date(timestamp).toLocaleString() : null;
+  }, [data]);
+
+  return (
+    <div className={styles.widget}>
+      <div className={styles.header}>
+        <span
+          className={`${styles.pill} ${loading ? styles.loading : allUp ? styles.online : styles.offline}`}
+        >
+          {loading ? 'LOADING' : allUp ? 'UP' : 'ISSUES'}
+        </span>
+        {lastChecked ? <span className={styles.meta}>Last checked {lastChecked}</span> : null}
+      </div>
+      <p className={styles.headline}>{headline}</p>
+      {error ? <p className={styles.error}>{error}</p> : null}
+
+      {showServices ? (
+        <div className={styles.serviceGrid}>
+          {loading ? (
+            <p className="muted">Gathering live status...</p>
+          ) : data && data.services.length > 0 ? (
+            data.services.map((service) => (
+              <div key={service.name} className={styles.serviceCard}>
+                <div className={styles.serviceHeader}>
+                  <span className={styles.serviceName}>{service.name}</span>
+                  <span
+                    className={`${styles.servicePill} ${
+                      service.status === 'UP' ? styles.online : styles.offline
+                    }`}
+                  >
+                    {service.status}
+                  </span>
+                </div>
+                {service.lastChecked ? (
+                  <p className={styles.serviceMeta}>
+                    Last checked {new Date(service.lastChecked).toLocaleString()}
+                  </p>
+                ) : null}
+                {service.message ? <p className={styles.serviceMessage}>{service.message}</p> : null}
+              </div>
+            ))
+          ) : (
+            <p className="muted">No services reported yet.</p>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/status/useStatusData.ts
+++ b/src/components/status/useStatusData.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { fetchStatus, type StatusResult } from '@/lib/status';
+
+type StatusState = {
+  data: StatusResult | null;
+  loading: boolean;
+  error: string | null;
+};
+
+const initialState: StatusState = {
+  data: null,
+  loading: true,
+  error: null
+};
+
+export function useStatusData() {
+  const [state, setState] = useState<StatusState>(initialState);
+
+  useEffect(() => {
+    let active = true;
+
+    async function load() {
+      setState((prev) => ({ ...prev, loading: true }));
+      try {
+        const result = await fetchStatus();
+        if (!active) return;
+
+        if (result.source === 'error') {
+          setState({ data: null, loading: false, error: result.message ?? 'Unable to fetch status' });
+          return;
+        }
+
+        setState({ data: result, loading: false, error: null });
+      } catch (error) {
+        if (!active) return;
+        setState({
+          data: null,
+          loading: false,
+          error: error instanceof Error ? error.message : 'Unable to fetch status'
+        });
+      }
+    }
+
+    load();
+    const interval = setInterval(load, 20000);
+
+    return () => {
+      active = false;
+      clearInterval(interval);
+    };
+  }, []);
+
+  return state;
+}

--- a/src/lib/status.ts
+++ b/src/lib/status.ts
@@ -1,0 +1,89 @@
+export type ServiceStatus = {
+  name: string;
+  status: 'UP' | 'DOWN';
+  lastChecked?: string;
+  message?: string;
+};
+
+export type StatusResult = {
+  ok: boolean;
+  services: ServiceStatus[];
+  checkedAt?: string;
+  source: 'status' | 'health' | 'error';
+  message?: string;
+};
+
+function normalizeStatusStatus(value: unknown): 'UP' | 'DOWN' {
+  if (typeof value === 'string' && value.toUpperCase() === 'UP') {
+    return 'UP';
+  }
+  return 'DOWN';
+}
+
+function buildHealthFallback(data: any): StatusResult {
+  const ok = Boolean(data?.ok ?? data?.status === 'ok' ?? data?.status === 'ONLINE');
+  const timestamp = data?.ts ? new Date(data.ts).toISOString() : new Date().toISOString();
+
+  return {
+    ok,
+    services: [
+      {
+        name: data?.service || 'web',
+        status: ok ? 'UP' : 'DOWN',
+        lastChecked: timestamp,
+        message: data?.message
+      }
+    ],
+    checkedAt: timestamp,
+    source: 'health',
+    message: data?.message
+  };
+}
+
+export async function fetchStatus(signal?: AbortSignal): Promise<StatusResult> {
+  const endpoints = ['/api/status', '/api/health'];
+  let lastError: unknown;
+
+  for (const endpoint of endpoints) {
+    try {
+      const response = await fetch(endpoint, { cache: 'no-store', signal });
+      if (!response.ok) {
+        if (response.status === 404) continue;
+        lastError = new Error(`Request failed with status ${response.status}`);
+        continue;
+      }
+
+      const data = await response.json();
+
+      if (endpoint.includes('/status') && Array.isArray(data?.services)) {
+        const services: ServiceStatus[] = data.services.map((service: any, index: number) => ({
+          name: service?.name || `service-${index + 1}`,
+          status: normalizeStatusStatus(service?.status ?? (service?.ok ? 'UP' : 'DOWN')),
+          lastChecked: service?.lastChecked || service?.ts,
+          message: service?.message
+        }));
+
+        return {
+          ok: services.every((service) => service.status === 'UP'),
+          services,
+          checkedAt: data?.checkedAt || data?.ts,
+          source: 'status',
+          message: data?.message
+        };
+      }
+
+      return buildHealthFallback(data);
+    } catch (error) {
+      lastError = error;
+      continue;
+    }
+  }
+
+  return {
+    ok: false,
+    services: [],
+    checkedAt: new Date().toISOString(),
+    source: 'error',
+    message: lastError instanceof Error ? lastError.message : 'Unable to fetch status'
+  };
+}


### PR DESCRIPTION
## Summary
- add shared navigation/footer for the marketing site
- redesign the homepage and add OS, stack, and status subpages
- introduce a reusable status widget that falls back from /api/status to /api/health

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920ca390f0c83299122d01941703ec0)