### PR TITLE
Add brand kit page and navigation link

### DIFF
--- a/app/brand/kit/page.tsx
+++ b/app/brand/kit/page.tsx
@@ -1,0 +1,5 @@
+import BrandKitPage from '@/components/brand/BrandKitPage';
+
+export default function Page() {
+  return <BrandKitPage />;
+}

--- a/src/components/brand/BrandKitPage.module.css
+++ b/src/components/brand/BrandKitPage.module.css
@@ -1,0 +1,262 @@
+:global(:root) {
+  --br-gradient-start: #ff9d00;
+  --br-gradient-mid: #ff6b00;
+  --br-gradient-hot: #ff0066;
+  --os-gradient-start: #ff006b;
+  --os-gradient-mid: #d600aa;
+  --os-gradient-deep: #7700ff;
+  --os-gradient-end: #0066ff;
+}
+
+.brandPage {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.surface {
+  background: #0a0a0a;
+  border: 1px solid #1f1f1f;
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 22px 60px rgba(0, 0, 0, 0.35);
+}
+
+.hero {
+  position: relative;
+  overflow: hidden;
+  padding: 2rem;
+}
+
+.heroBackground {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 15% 20%, rgba(255, 157, 0, 0.18), transparent 30%),
+    radial-gradient(circle at 80% 10%, rgba(0, 102, 255, 0.14), transparent 28%),
+    radial-gradient(circle at 60% 70%, rgba(255, 0, 107, 0.12), transparent 30%),
+    linear-gradient(135deg, rgba(255, 157, 0, 0.12) 0%, rgba(0, 102, 255, 0.08) 100%);
+  filter: blur(8px);
+  opacity: 0.8;
+}
+
+.heroContent {
+  position: relative;
+  display: grid;
+  gap: 0.75rem;
+  max-width: 780px;
+}
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.badge {
+  border: 1px solid #2b2b2b;
+  background: rgba(255, 255, 255, 0.04);
+  color: #e5e7eb;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.badgeDot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--br-gradient-start), var(--os-gradient-end));
+  display: inline-block;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+
+.sectionTitle {
+  margin: 0;
+}
+
+.sectionDescription {
+  margin: 0;
+  color: #9ba3af;
+  max-width: 620px;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  background: #0c0c0f;
+  border: 1px solid #1f1f1f;
+  border-radius: 16px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.65rem;
+}
+
+.swatch {
+  height: 120px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.label {
+  font-size: 0.95rem;
+  color: #d5d8e1;
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  align-items: baseline;
+}
+
+.subtle {
+  color: #9ba3af;
+  font-size: 0.85rem;
+}
+
+.gridHalf {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+
+.ruleCard {
+  background: linear-gradient(135deg, rgba(255, 0, 102, 0.09), rgba(0, 102, 255, 0.08));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.ruleList {
+  display: grid;
+  gap: 0.4rem;
+  margin: 0;
+  padding-left: 1.1rem;
+  color: #d5d8e1;
+}
+
+.typographyBlock {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.typographyRow {
+  display: flex;
+  justify-content: space-between;
+  color: #9ba3af;
+  font-size: 0.95rem;
+}
+
+.sampleHeading {
+  font-size: 2rem;
+  margin: 0;
+  font-weight: 800;
+}
+
+.sampleParagraph {
+  margin: 0;
+  line-height: 1.6;
+  color: #cdd1db;
+}
+
+.tokenGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.token {
+  padding: 0.9rem 1rem;
+  border: 1px dashed #2d2d2d;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.02);
+  display: grid;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.tokenBar {
+  height: 10px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--br-gradient-start), var(--os-gradient-end));
+}
+
+.usageGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.usageCard {
+  background: #0c0c0f;
+  border: 1px solid #1f1f1f;
+  border-radius: 16px;
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: auto 1fr;
+}
+
+.usageVisual {
+  height: 140px;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  text-transform: uppercase;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.usageContent {
+  padding: 1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.codeBlock {
+  background: #0b0b0f;
+  border: 1px solid #1f1f1f;
+  border-radius: 14px;
+  padding: 1rem;
+  overflow-x: auto;
+  font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
+.callout {
+  border: 1px solid rgba(114, 228, 162, 0.4);
+  background: rgba(114, 228, 162, 0.08);
+  border-radius: 14px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding: 1.5rem;
+  }
+
+  .sectionHeader {
+    flex-direction: column;
+  }
+
+  .sampleHeading {
+    font-size: 1.6rem;
+  }
+}

--- a/src/components/brand/BrandKitPage.tsx
+++ b/src/components/brand/BrandKitPage.tsx
@@ -1,0 +1,298 @@
+import styles from './BrandKitPage.module.css';
+
+const gradientStops = [
+  { hex: '#FF9D00', name: 'Sunrise Orange' },
+  { hex: '#FF6B00', name: 'Warm Orange' },
+  { hex: '#FF0066', name: 'Hot Pink' },
+  { hex: '#FF006B', name: 'Electric Magenta' },
+  { hex: '#D600AA', name: 'Deep Magenta' },
+  { hex: '#7700FF', name: 'Vivid Purple' },
+  { hex: '#0066FF', name: 'Cyber Blue' }
+];
+
+const neutrals = [
+  { hex: '#000000', name: 'Pure Black' },
+  { hex: '#0A0A0A', name: 'Deep Black' },
+  { hex: '#1A1A1A', name: 'Charcoal' },
+  { hex: '#FFFFFF', name: 'Pure White' }
+];
+
+const gradients = [
+  {
+    name: 'BR Gradient',
+    direction: 'Top-to-bottom',
+    stops: 'linear-gradient(180deg,#FF9D00 0%,#FF6B00 25%,#FF0066 75%,#FF006B 100%)'
+  },
+  {
+    name: 'OS Gradient',
+    direction: 'Top-to-bottom',
+    stops: 'linear-gradient(180deg,#FF006B 0%,#D600AA 25%,#7700FF 75%,#0066FF 100%)'
+  }
+];
+
+const spacing = [
+  { label: 'XS', value: '4px', description: 'Tight spacing for badges and chips.' },
+  { label: 'SM', value: '8px', description: 'Compact gutters, icon padding.' },
+  { label: 'MD', value: '12px', description: 'Card interior padding, inline gaps.' },
+  { label: 'LG', value: '18px', description: 'Section gutters and stack spacing.' },
+  { label: 'XL', value: '24px', description: 'Panel padding and hero breathing room.' }
+];
+
+const usage = [
+  {
+    title: 'Gradient Frame',
+    description: 'Use BR→OS gradients for hero backdrops, buttons, and accent dividers.',
+    style: {
+      background:
+        'linear-gradient(135deg, var(--br-gradient-start) 0%, var(--br-gradient-hot) 30%, var(--os-gradient-deep) 70%, var(--os-gradient-end) 100%)'
+    }
+  },
+  {
+    title: 'Neutral Panels',
+    description: 'Pair vibrant gradients with deep neutral surfaces to preserve contrast and focus.',
+    style: { background: '#0a0a0a', border: '1px solid #1a1a1a' }
+  },
+  {
+    title: 'Monochrome Logo',
+    description: 'On busy photography, switch to a solid white or black wordmark for clarity.',
+    style: { background: '#1a1a1a' }
+  }
+];
+
+const dos = [
+  'Maintain vertical gradient flow for hero panels and large backgrounds.',
+  'Use ample padding between gradients and text for legibility.',
+  'Anchor the logo on neutral or lightly blurred gradient zones.'
+];
+
+const donts = [
+  "Don’t skew the gradient stops or introduce new hues.",
+  "Don’t place body copy directly on top of hot pink or blue stops without contrast support.",
+  "Don’t stretch the logotype or add drop shadows to the mark."
+];
+
+export function BrandKitPage() {
+  return (
+    <div className={styles.brandPage}>
+      <section className={`${styles.surface} ${styles.hero}`}>
+        <div className={styles.heroBackground} aria-hidden />
+        <div className={styles.heroContent}>
+          <p className="muted">Visual language</p>
+          <h1>BlackRoad OS Brand Kit</h1>
+          <p className={styles.sectionDescription}>
+            Extracted directly from the provided gradients and palette. This kit captures the BR → OS
+            color system, typography, spacing, and usage rules needed to build new surfaces without
+            deviating from the core identity.
+          </p>
+          <div className={styles.badges}>
+            <span className={styles.badge}>
+              <span className={styles.badgeDot} aria-hidden /> BR → OS gradient spine
+            </span>
+            <span className={styles.badge}>
+              <span className={styles.badgeDot} aria-hidden /> System font stack
+            </span>
+            <span className={styles.badge}>
+              <span className={styles.badgeDot} aria-hidden /> Dark canvas + high contrast
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.surface}>
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>Primary Gradient Stops</h2>
+          <p className={styles.sectionDescription}>Core BR/OS stops used in hero frames, glows, and CTAs.</p>
+        </div>
+        <div className={styles.grid}>
+          {gradientStops.map((stop) => (
+            <div key={stop.hex} className={styles.card}>
+              <div className={styles.swatch} style={{ background: stop.hex }} aria-hidden />
+              <div className={styles.label}>
+                <span>{stop.hex}</span>
+                <span className={styles.subtle}>{stop.name}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.surface}>
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>Core Neutrals</h2>
+          <p className={styles.sectionDescription}>
+            Neutrals keep the gradients grounded. Use them for panels, overlays, and typography bases.
+          </p>
+        </div>
+        <div className={styles.grid}>
+          {neutrals.map((neutral) => (
+            <div key={neutral.hex} className={styles.card}>
+              <div className={styles.swatch} style={{ background: neutral.hex }} aria-hidden />
+              <div className={styles.label}>
+                <span>{neutral.hex}</span>
+                <span className={styles.subtle}>{neutral.name}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.surface}>
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>BR → OS Gradients</h2>
+          <p className={styles.sectionDescription}>Vertical flows carry the brand from BR into OS moments.</p>
+        </div>
+        <div className={styles.grid}>
+          {gradients.map((gradient) => (
+            <div key={gradient.name} className={styles.card}>
+              <div className={styles.swatch} style={{ background: gradient.stops }} aria-hidden />
+              <div className={styles.label}>
+                <span>{gradient.name}</span>
+                <span className={styles.subtle}>{gradient.direction}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.surface}>
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>Typography</h2>
+          <p className={styles.sectionDescription}>
+            System-native sans keeps the UI nimble and legible. Pair bold headings with relaxed body
+            copy for technical clarity.
+          </p>
+        </div>
+        <div className={styles.gridHalf}>
+          <div className={styles.typographyBlock}>
+            <p className={styles.typographyRow}>
+              <span>BR Sans</span>
+              <span>Inter / -apple-system / Segoe UI</span>
+            </p>
+            <h3 className={styles.sampleHeading}>Gradient-first identity</h3>
+            <p className={styles.sampleParagraph}>
+              Use tight leading for titles and generous spacing beneath to let the gradients breathe.
+              Body copy should stay at 16–18px with 1.6 line-height for readable docs and dashboards.
+            </p>
+          </div>
+          <div className={styles.ruleCard}>
+            <strong>Type ratios</strong>
+            <ul className={styles.ruleList}>
+              <li>H1: 42px / 800 weight</li>
+              <li>H2: 26px / 700 weight</li>
+              <li>Body: 16–18px / 400–500 weight</li>
+              <li>All caps nav: 12–14px / letter spacing 0.08em</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.surface}>
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>Spacing System</h2>
+          <p className={styles.sectionDescription}>
+            Consistent padding ensures the gradients never overpower the content. Use these tokens in
+            layout primitives.
+          </p>
+        </div>
+        <div className={styles.tokenGrid}>
+          {spacing.map((token) => (
+            <div key={token.label} className={styles.token}>
+              <div className={styles.typographyRow}>
+                <span>{token.label}</span>
+                <span className={styles.subtle}>{token.value}</span>
+              </div>
+              <div className={styles.tokenBar} style={{ width: token.value }} aria-hidden />
+              <p className={styles.subtle}>{token.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.surface}>
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>Usage Guidelines</h2>
+          <p className={styles.sectionDescription}>
+            Keep gradients purposeful and typography readable. Pair them with neutrals for accessibility.
+          </p>
+        </div>
+        <div className={styles.usageGrid}>
+          {usage.map((item) => (
+            <div key={item.title} className={styles.usageCard}>
+              <div className={styles.usageVisual} style={item.style}>
+                {item.title}
+              </div>
+              <div className={styles.usageContent}>
+                <strong>{item.title}</strong>
+                <p className={styles.subtle}>{item.description}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+        <div className={styles.gridHalf}>
+          <div className={styles.callout}>
+            <strong>Do</strong>
+            <ul className={styles.ruleList}>
+              {dos.map((rule) => (
+                <li key={rule}>{rule}</li>
+              ))}
+            </ul>
+          </div>
+          <div className={styles.callout}>
+            <strong>Don’t</strong>
+            <ul className={styles.ruleList}>
+              {donts.map((rule) => (
+                <li key={rule}>{rule}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className={styles.surface}>
+        <div className={styles.sectionHeader}>
+          <h2 className={styles.sectionTitle}>Implementation</h2>
+          <p className={styles.sectionDescription}>
+            Copy/paste-ready snippets for gradients, buttons, and surfaces using the provided palette.
+          </p>
+        </div>
+        <div className={styles.gridHalf}>
+          <div className={styles.codeBlock}>
+            <pre>
+              <code>{`/* Gradients */
+.br-gradient {
+  background: linear-gradient(180deg,#FF9D00 0%,#FF6B00 25%,#FF0066 75%,#FF006B 100%);
+}
+.os-gradient {
+  background: linear-gradient(180deg,#FF006B 0%,#D600AA 25%,#7700FF 75%,#0066FF 100%);
+}
+/* Button */
+.btn-primary {
+  padding: 12px 18px;
+  border-radius: 12px;
+  color: #fff;
+  background: linear-gradient(135deg,#FF9D00,#FF006B,#0066FF);
+}`}</code>
+            </pre>
+          </div>
+          <div className={styles.codeBlock}>
+            <pre>
+              <code>{`/* Surfaces */
+.panel {
+  background: #0A0A0A;
+  border: 1px solid #1A1A1A;
+  color: #FFFFFF;
+}
+/* Typography */
+:root {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.6;
+}`}</code>
+            </pre>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default BrandKitPage;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -8,6 +8,7 @@ const navItems = [
   { href: '/', label: 'Home', external: false },
   { href: '/os', label: 'OS', external: false },
   { href: '/stack', label: 'Stack', external: false },
+  { href: '/brand/kit', label: 'Brand Kit', external: false },
   { href: '/status', label: 'Status', external: false },
   { href: 'https://docs.blackroad.systems', label: 'Docs', external: true }
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,24 +26,6 @@
       "@/config/*": ["src/config/*"],
       "@/types/*": ["src/types/*"],
       "@/*": ["./*"]
-      "@/components/*": [
-        "src/components/*"
-      ],
-      "@/lib/*": [
-        "src/lib/*"
-      ],
-      "@/config": [
-        "src/config"
-      ],
-      "@/config/*": [
-        "src/config/*"
-      ],
-      "@/types/*": [
-        "src/types/*"
-      ],
-      "@/*": [
-        "./*"
-      ]
     },
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- add a dedicated BrandKitPage component showcasing palette, gradients, typography, spacing, and usage guidance
- expose the new brand kit at /brand/kit and link it from the site header
- clean up tsconfig path entries to keep TypeScript and linting working

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920fcf4510c8329b7d6daafe87ecb1b)