### PR TITLE
Add typography and spacing guidelines page

### DIFF
--- a/app/typography/page.module.css
+++ b/app/typography/page.module.css
@@ -1,0 +1,466 @@
+.page {
+  --br-bg: #000000;
+  --br-surface: #0a0a0a;
+  --br-surface-alt: #111111;
+  --br-border-subtle: rgba(255, 255, 255, 0.08);
+  --br-text: #ffffff;
+  --br-muted: #a3a3a3;
+  --br-accent-warm: #ff9d00;
+  --br-accent-mid: #ff006b;
+  --br-accent-cool: #0066ff;
+  --br-radius-lg: 24px;
+  --br-radius-md: 18px;
+  --br-radius-sm: 12px;
+  --br-shadow-soft: 0 18px 45px rgba(0, 0, 0, 0.55);
+  --br-font-sans: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, sans-serif;
+  --br-font-mono: 'JetBrains Mono', 'SF Mono', ui-monospace, Menlo, Monaco, Consolas,
+    'Liberation Mono', monospace;
+
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+  padding: 40px 16px 72px;
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.04), transparent 55%),
+    var(--br-bg);
+  color: var(--br-text);
+  font-family: var(--br-font-sans);
+  -webkit-font-smoothing: antialiased;
+}
+
+.shell {
+  max-width: 1120px;
+  margin: 0 auto;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.01));
+  border-radius: 32px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--br-shadow-soft);
+  padding: 32px clamp(20px, 4vw, 40px) 48px;
+  backdrop-filter: blur(18px);
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 3fr) minmax(260px, 2fr);
+  gap: 28px;
+  align-items: center;
+  margin-bottom: 32px;
+}
+
+.heroBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 10px 4px 4px;
+  border-radius: 999px;
+  background: rgba(10, 10, 10, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--br-muted);
+  margin-bottom: 14px;
+}
+
+.heroBadgeChip {
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  background: conic-gradient(
+    from 200deg,
+    var(--br-accent-warm),
+    #ff0066,
+    #7700ff,
+    var(--br-accent-cool),
+    var(--br-accent-warm)
+  );
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.heroBadgeChip::after {
+  content: 'Aa';
+  font-size: 11px;
+  font-weight: 700;
+  color: #000;
+}
+
+.page h1 {
+  font-size: clamp(30px, 4vw, 40px);
+  line-height: 1.05;
+  margin: 0 0 10px;
+  letter-spacing: -0.03em;
+}
+
+.page h1 span {
+  background: linear-gradient(120deg, var(--br-accent-warm), var(--br-accent-mid), var(--br-accent-cool));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.heroSubtitle {
+  font-size: 14px;
+  max-width: 520px;
+  color: var(--br-muted);
+  line-height: 1.8;
+  margin-bottom: 18px;
+}
+
+.heroMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 20px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(237, 242, 255, 0.75);
+}
+
+.heroMeta strong {
+  color: var(--br-accent-mid);
+  font-weight: 600;
+}
+
+.heroTypeCard {
+  justify-self: center;
+  max-width: 360px;
+  width: 100%;
+  padding: 20px;
+  border-radius: var(--br-radius-lg);
+  background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.12), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(0, 102, 255, 0.18), transparent 60%),
+    #050505;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  position: relative;
+  overflow: hidden;
+}
+
+.heroTypeCard::before {
+  content: 'Typography System';
+  position: absolute;
+  top: 14px;
+  right: 16px;
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.heroTypeDisplay {
+  font-size: 42px;
+  letter-spacing: -0.04em;
+  margin-bottom: 12px;
+  font-weight: 800;
+  display: flex;
+  gap: 6px;
+}
+
+.heroTypeDisplay span:nth-child(1) {
+  background: linear-gradient(180deg, #ff9d00 0%, #ff6b00 25%, #ff0066 75%, #ff006b 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.heroTypeDisplay span:nth-child(2) {
+  background: linear-gradient(180deg, #ff006b 0%, #d600aa 25%, #7700ff 75%, #0066ff 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.heroTypeMeta {
+  font-size: 12px;
+  color: var(--br-muted);
+  line-height: 1.6;
+}
+
+.section {
+  margin-top: 32px;
+  padding-top: 28px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.section:first-of-type {
+  margin-top: 12px;
+  border-top: none;
+  padding-top: 0;
+}
+
+.section h2 {
+  font-size: 18px;
+  margin: 0 0 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+}
+
+.sectionSub {
+  font-size: 13px;
+  color: var(--br-muted);
+  margin-bottom: 16px;
+  max-width: 620px;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(8, 8, 8, 0.9);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--br-muted);
+  margin-bottom: 8px;
+}
+
+.pillDot {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: radial-gradient(circle at 30% 20%, #ffffff, #ff9d00);
+}
+
+.page p,
+.page ul {
+  font-size: 14px;
+  line-height: 1.8;
+  color: rgba(237, 242, 255, 0.95);
+  margin: 0 0 12px;
+}
+
+.page ul {
+  padding-left: 1.25rem;
+  margin: 0 0 10px;
+}
+
+.page li + li {
+  margin-top: 2px;
+}
+
+.grid {
+  display: grid;
+  gap: 18px;
+}
+
+@media (min-width: 860px) {
+  .gridTwo {
+    grid-template-columns: minmax(0, 3fr) minmax(0, 2.1fr);
+  }
+
+  .gridThree {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.card {
+  background: var(--br-surface);
+  border-radius: var(--br-radius-md);
+  border: 1px solid var(--br-border-subtle);
+  padding: 18px 18px 20px;
+}
+
+.cardHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 8px;
+  gap: 10px;
+}
+
+.cardTitle {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+}
+
+.cardTag {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--br-muted);
+}
+
+.mono {
+  font-family: var(--br-font-mono);
+  font-size: 12px;
+  color: rgba(246, 248, 255, 0.95);
+}
+
+.typeRow {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.typeLabel {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--br-muted);
+  margin-bottom: 3px;
+}
+
+.typeToken {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom: 4px;
+}
+
+.typeSample {
+  margin-top: 4px;
+}
+
+.scaleTable {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 8px;
+}
+
+.scaleTable th,
+.scaleTable td {
+  text-align: left;
+  padding: 6px 4px;
+  font-size: 12px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.09);
+}
+
+.scaleTable th {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.callout {
+  margin-top: 10px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(10, 10, 10, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  font-size: 13px;
+  color: var(--br-muted);
+}
+
+.callout strong {
+  color: var(--br-text);
+}
+
+.spacingGrid {
+  display: grid;
+  gap: 14px;
+}
+
+@media (min-width: 720px) {
+  .spacingGrid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.spaceChip {
+  border-radius: 14px;
+  background: var(--br-surface-alt);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 14px 14px 16px;
+}
+
+.spaceLabel {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--br-muted);
+  margin-bottom: 6px;
+}
+
+.spaceVis {
+  height: 32px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--br-accent-warm), var(--br-accent-mid), var(--br-accent-cool));
+  margin-bottom: 6px;
+  position: relative;
+  overflow: hidden;
+}
+
+.spaceVis::after {
+  content: '';
+  position: absolute;
+  inset: 4px;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.5);
+}
+
+.spaceValue {
+  font-size: 13px;
+  font-family: var(--br-font-mono);
+}
+
+.exampleLayout {
+  margin-top: 14px;
+  padding: 14px;
+  border-radius: 18px;
+  background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.08), transparent 55%),
+    rgba(10, 10, 10, 0.96);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+}
+
+.exampleHeader {
+  padding: 16px 16px 12px;
+  border-radius: 14px;
+  background: rgba(0, 0, 0, 0.85);
+  margin-bottom: 12px;
+}
+
+.exampleHeader h3 {
+  margin: 0 0 4px;
+  font-size: 18px;
+  letter-spacing: -0.02em;
+}
+
+.exampleHeader p {
+  font-size: 13px;
+  margin: 0;
+  color: var(--br-muted);
+}
+
+.exampleBody {
+  display: grid;
+  gap: 10px;
+}
+
+@media (min-width: 720px) {
+  .exampleBody {
+    grid-template-columns: 2.2fr 1.4fr;
+  }
+}
+
+.exampleCard {
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(5, 5, 5, 0.95);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  font-size: 13px;
+  color: var(--br-muted);
+}
+
+.footer {
+  margin-top: 40px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  font-size: 11px;
+  color: var(--br-muted);
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+@media (max-width: 820px) {
+  .hero {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/app/typography/page.tsx
+++ b/app/typography/page.tsx
@@ -1,0 +1,356 @@
+import styles from './page.module.css';
+
+export const metadata = {
+  title: 'BlackRoad OS — Typography',
+  description: 'Typography and spacing system guidelines for BlackRoad OS.'
+};
+
+export default function TypographyPage() {
+  return (
+    <div className={styles.page}>
+      <div className={styles.shell}>
+        <header className={styles.hero}>
+          <div>
+            <div className={styles.heroBadge}>
+              <span className={styles.heroBadgeChip} />
+              <span>BlackRoad OS · Type &amp; Spacing</span>
+            </div>
+            <h1>
+              <span>BlackRoad OS</span> Typography System
+            </h1>
+            <p className={styles.heroSubtitle}>
+              Opinionated rules for type scale, line heights, and spacing so every BlackRoad surface
+              feels like the same OS – from Prism Console to docs to marketing.
+            </p>
+            <div className={styles.heroMeta}>
+              <span>
+                <strong>Family</strong>&nbsp;&nbsp;System sans, UI-first
+              </span>
+              <span>
+                <strong>Scale</strong>&nbsp;&nbsp;Golden-ish, 1.25/1.6
+              </span>
+              <span>
+                <strong>Grid</strong>&nbsp;&nbsp;4px core, 8/12/24 clusters
+              </span>
+            </div>
+          </div>
+          <aside className={styles.heroTypeCard}>
+            <div className={styles.heroTypeDisplay}>
+              <span>BR</span>
+              <span>OS</span>
+            </div>
+            <div className={styles.heroTypeMeta}>
+              Primary UI font:
+              <span className={styles.mono}>
+                {' '}
+                -apple-system, BlinkMacSystemFont, &quot;SF Pro Text&quot;, &quot;Segoe UI&quot;
+              </span>
+              . Calm, high-legibility grotesk tuned for dense operator consoles.
+            </div>
+          </aside>
+        </header>
+
+        <section id="stack" className={styles.section}>
+          <div className={styles.pill}>
+            <span className={styles.pillDot} />
+            <span>Section 01</span>
+          </div>
+          <h2>Font Stack &amp; Roles</h2>
+          <p className={styles.sectionSub}>
+            BlackRoad favors system sans for speed and familiarity. Monospace is reserved for IDs,
+            hashes, and anything an operator might copy-paste into a terminal.
+          </p>
+          <div className={`${styles.grid} ${styles.gridTwo}`}>
+            <div className={styles.card}>
+              <div className={styles.cardHeader}>
+                <div className={styles.cardTitle}>Primary UI Sans</div>
+                <div className={styles.cardTag}>General Interface</div>
+              </div>
+              <p>
+                Use the system sans stack everywhere in product UI: headings, labels, buttons, and
+                body.
+              </p>
+              <div className={styles.typeRow}>
+                <div className={styles.typeLabel}>CSS Stack</div>
+                <div className={styles.mono}>
+                  font-family: -apple-system, BlinkMacSystemFont, &quot;SF Pro Text&quot;, &quot;Segoe UI&quot;, Roboto,
+                  &quot;Helvetica Neue&quot;, Arial, sans-serif;
+                </div>
+              </div>
+              <div className={styles.typeRow}>
+                <div className={styles.typeLabel}>Recommended Weights</div>
+                <div className={styles.typeToken}>
+                  400 – Body · 500 – Emphasis · 600 – Section titles · 700 – Key headings
+                </div>
+              </div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.cardHeader}>
+                <div className={styles.cardTitle}>Monospace Layer</div>
+                <div className={styles.cardTag}>Hashes &amp; Logs</div>
+              </div>
+              <p>Use monospace only where alignment and legibility of technical strings matters.</p>
+              <div className={styles.typeRow}>
+                <div className={styles.typeLabel}>CSS Stack</div>
+                <div className={styles.mono}>
+                  font-family: &quot;JetBrains Mono&quot;, &quot;SF Mono&quot;, ui-monospace, Menlo, Monaco, Consolas,
+                  &quot;Liberation Mono&quot;, monospace;
+                </div>
+              </div>
+              <div className={styles.typeRow}>
+                <div className={styles.typeLabel}>Use For</div>
+                <ul>
+                  <li>Agent IDs, ledger hashes, transaction refs</li>
+                  <li>Code examples, CLI snippets, JSON blobs</li>
+                  <li>Tables where numbers must align</li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section id="scale" className={styles.section}>
+          <div className={styles.pill}>
+            <span className={styles.pillDot} />
+            <span>Section 02</span>
+          </div>
+          <h2>Type Scale</h2>
+          <p className={styles.sectionSub}>
+            A compact, golden-ish scale keeps dashboards dense but readable. These are canonical tokens
+            for product and docs.
+          </p>
+          <div className={`${styles.grid} ${styles.gridTwo}`}>
+            <div className={styles.card}>
+              <div className={styles.cardHeader}>
+                <div className={styles.cardTitle}>Scale Tokens</div>
+                <div className={styles.cardTag}>Rem-based</div>
+              </div>
+              <table className={styles.scaleTable}>
+                <thead>
+                  <tr>
+                    <th>Token</th>
+                    <th>Usage</th>
+                    <th>Size</th>
+                    <th>Line-height</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>
+                      <code>text-xs</code>
+                    </td>
+                    <td>Meta labels, pills</td>
+                    <td>0.75rem</td>
+                    <td>1.4</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <code>text-sm</code>
+                    </td>
+                    <td>Dense UI</td>
+                    <td>0.875rem</td>
+                    <td>1.5</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <code>text-md</code>
+                    </td>
+                    <td>Body</td>
+                    <td>1.0rem</td>
+                    <td>1.7</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <code>text-lg</code>
+                    </td>
+                    <td>Section titles</td>
+                    <td>1.25rem</td>
+                    <td>1.5</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <code>text-xl</code>
+                    </td>
+                    <td>H2</td>
+                    <td>1.5rem</td>
+                    <td>1.3</td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <code>text-2xl</code>
+                    </td>
+                    <td>H1 / hero</td>
+                    <td>2.0rem</td>
+                    <td>1.1</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div className={styles.callout}>
+                <strong>Rule:</strong> never go below <code>text-sm</code> for interactive UI copy.
+                Reserve <code>text-xs</code> for metadata only.
+              </div>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.cardHeader}>
+                <div className={styles.cardTitle}>Hierarchy Examples</div>
+                <div className={styles.cardTag}>Live Samples</div>
+              </div>
+              <div className={styles.typeRow}>
+                <div className={styles.typeLabel}>H1 / View Title</div>
+                <div className={`${styles.typeToken} ${styles.mono}`}>
+                  font-size: 2rem; line-height: 1.1; font-weight: 700;
+                </div>
+                <div
+                  className={styles.typeSample}
+                  style={{ fontSize: '2rem', lineHeight: 1.1, fontWeight: 700, letterSpacing: '-0.03em', marginTop: 4 }}
+                >
+                  Agent Orchestration Overview
+                </div>
+              </div>
+              <div className={styles.typeRow}>
+                <div className={styles.typeLabel}>H2 / Section</div>
+                <div className={`${styles.typeToken} ${styles.mono}`}>
+                  font-size: 1.5rem; line-height: 1.3; font-weight: 600;
+                </div>
+                <div
+                  className={styles.typeSample}
+                  style={{ fontSize: '1.5rem', lineHeight: 1.3, fontWeight: 600, marginTop: 4 }}
+                >
+                  RoadChain Activity
+                </div>
+              </div>
+              <div className={styles.typeRow}>
+                <div className={styles.typeLabel}>Body</div>
+                <div className={`${styles.typeToken} ${styles.mono}`}>
+                  font-size: 1rem; line-height: 1.7; font-weight: 400;
+                </div>
+                <div
+                  className={styles.typeSample}
+                  style={{ fontSize: '1rem', lineHeight: 1.7, marginTop: 4, color: 'var(--br-muted)' }}
+                >
+                  Every event is timestamped, hashed, and linked to a human or agent identity.
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section id="spacing" className={styles.section}>
+          <div className={styles.pill}>
+            <span className={styles.pillDot} />
+            <span>Section 03</span>
+          </div>
+          <h2>Spacing System</h2>
+          <p className={styles.sectionSub}>
+            Spacing follows a 4px core grid with preferred jumps that feel slightly golden – 4, 8, 12,
+            16, 24, 32, 40, 64. Use these tokens for padding, gaps, and margins.
+          </p>
+          <div className={styles.spacingGrid}>
+            <div className={styles.spaceChip}>
+              <div className={styles.spaceLabel}>Tight</div>
+              <div className={styles.spaceVis} style={{ width: '40%' }} />
+              <div className={styles.spaceValue}>4px · 8px · 12px — label gaps, pill padding, icon offsets.</div>
+            </div>
+            <div className={styles.spaceChip}>
+              <div className={styles.spaceLabel}>Core</div>
+              <div className={styles.spaceVis} style={{ width: '65%' }} />
+              <div className={styles.spaceValue}>16px · 24px — card padding, section gutters, column gaps.</div>
+            </div>
+            <div className={styles.spaceChip}>
+              <div className={styles.spaceLabel}>Hero</div>
+              <div className={styles.spaceVis} style={{ width: '90%' }} />
+              <div className={styles.spaceValue}>32px · 40px · 64px — outer shell padding, hero breathing room.</div>
+            </div>
+          </div>
+          <div className={styles.callout} style={{ marginTop: 14 }}>
+            <strong>Rule of three:</strong> within a single screen, try to stick to three spacing sizes
+            max (e.g., 8px, 16px, 32px). This keeps the OS feeling intentional and grid-aligned.
+          </div>
+        </section>
+
+        <section id="examples" className={styles.section}>
+          <div className={styles.pill}>
+            <span className={styles.pillDot} />
+            <span>Section 04</span>
+          </div>
+          <h2>Composed Examples</h2>
+          <p className={styles.sectionSub}>
+            How the typography and spacing tokens come together in real UI: a typical operator view with
+            a hero, metrics, and logs.
+          </p>
+          <div className={styles.exampleLayout}>
+            <div className={styles.exampleHeader}>
+              <h3 style={{ fontSize: '1.5rem', fontWeight: 600, letterSpacing: '-0.02em' }}>
+                Prism Console · Live Agents
+              </h3>
+              <p>Typography: text-2xl / text-md. Spacing: 24px shell, 16px inner, 8px meta.</p>
+            </div>
+            <div className={styles.exampleBody}>
+              <div className={styles.exampleCard}>
+                <div className={styles.typeLabel}>Panel Title (H2)</div>
+                <div style={{ fontSize: '1.25rem', fontWeight: 600, marginBottom: 4 }}>Active Agent Swarm</div>
+                <p style={{ margin: '0 0 6px' }}>42 agents online · 6 pending · 1 requiring manual review.</p>
+                <p style={{ margin: 0, fontSize: 12, color: 'var(--br-muted)' }}>
+                  Body copy at 1rem or 0.875rem with 1.7 line-height keeps dense metrics readable.
+                </p>
+              </div>
+              <div className={styles.exampleCard}>
+                <div className={styles.typeLabel}>Log Row</div>
+                <div className={styles.mono} style={{ fontSize: 12 }}>
+                  2025-11-21T17:03Z · agent-042 · routed_order · tx: 0x8f9c…b21e
+                </div>
+                <p style={{ margin: '6px 0 0', fontSize: 12, color: 'var(--br-muted)' }}>
+                  Monospace only for data you might copy. Keep log rows at <code>text-sm</code> with 1.5
+                  line-height.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section id="rules" className={styles.section}>
+          <div className={styles.pill}>
+            <span className={styles.pillDot} />
+            <span>Section 05</span>
+          </div>
+          <h2>Do &amp; Don&apos;t</h2>
+          <p className={styles.sectionSub}>
+            A few guardrails so the BlackRoad OS typographic voice stays calm, legible, and consistent
+            across every repo.
+          </p>
+          <div className={`${styles.grid} ${styles.gridTwo}`}>
+            <div className={styles.card}>
+              <div className={styles.cardHeader}>
+                <div className={styles.cardTitle}>Do</div>
+                <div className={styles.cardTag}>Good Patterns</div>
+              </div>
+              <ul>
+                <li>Use a single sans family + monospace accent per view.</li>
+                <li>Keep heading levels sequential; don&apos;t jump from H1 to H4.</li>
+                <li>Use generous line-height (1.6–1.8) for dense explanations.</li>
+                <li>Align text to a core vertical rhythm using 4px/8px multiples.</li>
+              </ul>
+            </div>
+            <div className={styles.card}>
+              <div className={styles.cardHeader}>
+                <div className={styles.cardTitle}>Don&apos;t</div>
+                <div className={styles.cardTag}>Avoid</div>
+              </div>
+              <ul>
+                <li>Mix more than two font weights in a single panel.</li>
+                <li>Use all caps for long sentences; reserve for labels.</li>
+                <li>Drop below 12px for interactive text.</li>
+                <li>Ignore spacing tokens and invent one-off paddings.</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <footer className={styles.footer}>
+          <span>BlackRoad OS · Typography &amp; Spacing v1.0</span>
+          <span>Align to these tokens in every repo: web, console, docs, and brand.</span>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,5 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -8,6 +8,7 @@ const navItems = [
   { href: '/', label: 'Home', external: false },
   { href: '/os', label: 'OS', external: false },
   { href: '/stack', label: 'Stack', external: false },
+  { href: '/typography', label: 'Type & spacing', external: false },
   { href: '/status', label: 'Status', external: false },
   { href: 'https://docs.blackroad.systems', label: 'Docs', external: true }
 ];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -26,37 +22,9 @@
       "@/config/*": ["src/config/*"],
       "@/types/*": ["src/types/*"],
       "@/*": ["./*"]
-      "@/components/*": [
-        "src/components/*"
-      ],
-      "@/lib/*": [
-        "src/lib/*"
-      ],
-      "@/config": [
-        "src/config"
-      ],
-      "@/config/*": [
-        "src/config/*"
-      ],
-      "@/types/*": [
-        "src/types/*"
-      ],
-      "@/*": [
-        "./*"
-      ]
     },
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
+    "plugins": [{ "name": "next" }]
   },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    "next.config.mjs",
-    ".next/types/**/*.ts"
-  ],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "next.config.mjs", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- add a dedicated typography and spacing system page for BlackRoad OS with detailed guidance and live samples
- implement page-specific styling to mirror the provided design tokens and layout
- expose the new page in the site navigation and clean up tsconfig path aliases

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920fddaa8a883299859843e75bb0132)