### PR TITLE
Move brand kit CSS variables to global stylesheet

### DIFF
--- a/src/components/brand/BrandKitPage.module.css
+++ b/src/components/brand/BrandKitPage.module.css
@@ -1,13 +1,3 @@
-:global(:root) {
-  --br-gradient-start: #ff9d00;
-  --br-gradient-mid: #ff6b00;
-  --br-gradient-hot: #ff0066;
-  --os-gradient-start: #ff006b;
-  --os-gradient-mid: #d600aa;
-  --os-gradient-deep: #7700ff;
-  --os-gradient-end: #0066ff;
-}
-
 .brandPage {
   display: flex;
   flex-direction: column;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -66,3 +66,13 @@ p {
     font-size: 1.25rem;
   }
 }
+
+:root {
+  --br-gradient-start: #ff9d00;
+  --br-gradient-mid: #ff6b00;
+  --br-gradient-hot: #ff0066;
+  --os-gradient-start: #ff006b;
+  --os-gradient-mid: #d600aa;
+  --os-gradient-deep: #7700ff;
+  --os-gradient-end: #0066ff;
+}


### PR DESCRIPTION
## Summary
- remove the :global(:root) variables block from BrandKitPage.module.css
- add the CSS variable definitions to styles/globals.css under a :root selector

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69210667e91c8329ae13a4cdaa9abf95)