### PR TITLE
Add BlackRoad OS login page

### DIFF
--- a/app/login/LoginPage.module.css
+++ b/app/login/LoginPage.module.css
@@ -1,0 +1,550 @@
+.loginRoot {
+  --br-sunrise: #ff9d00;
+  --br-warm: #ff6b00;
+  --br-hot-pink: #ff0066;
+  --br-magenta: #ff006b;
+  --br-deep-magenta: #d600aa;
+  --br-purple: #7700ff;
+  --br-cyber-blue: #0066ff;
+
+  --br-grad-full: linear-gradient(
+    135deg,
+    #ff9d00 0%,
+    #ff6b00 16%,
+    #ff0066 32%,
+    #ff006b 48%,
+    #d600aa 64%,
+    #7700ff 80%,
+    #0066ff 100%
+  );
+  --br-grad-br: linear-gradient(180deg, #ff9d00 0%, #ff6b00 25%, #ff0066 75%, #ff006b 100%);
+  --br-grad-os: linear-gradient(180deg, #ff006b 0%, #d600aa 25%, #7700ff 75%, #0066ff 100%);
+
+  --br-bg: #020008;
+  --br-bg-alt: #05010f;
+  --br-shell: rgba(4, 4, 10, 0.96);
+  --br-surface: #0b0b12;
+  --br-surface-alt: #13131f;
+
+  --br-text: #ffffff;
+  --br-text-subtle: rgba(255, 255, 255, 0.76);
+  --br-text-faint: rgba(255, 255, 255, 0.55);
+
+  --radius-lg: 20px;
+  --radius-xl: 26px;
+  --radius-xxl: 32px;
+
+  --font-sans: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', 'SF Mono', ui-monospace, Menlo, monospace;
+
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+  color: var(--br-text);
+  background:
+    radial-gradient(circle at top, #1a1026 0, #05000b 45%, #000 100%),
+    radial-gradient(circle at 0 0, rgba(255, 255, 255, 0.05) 0, transparent 55%),
+    radial-gradient(circle at 100% 100%, rgba(0, 102, 255, 0.2) 0, transparent 55%);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+}
+
+:global(.br-login-body) {
+  margin: 0;
+  background: #000;
+}
+
+:global(.br-login-body) main {
+  max-width: none;
+  padding: 0;
+}
+
+:global(.br-login-body) header,
+:global(.br-login-body) footer {
+  display: none;
+}
+
+.frameShell {
+  position: relative;
+  width: 100%;
+  max-width: 1120px;
+  border-radius: var(--radius-xxl);
+  padding: 1px;
+  background:
+    radial-gradient(circle at 0 0, rgba(255, 255, 255, 0.18), transparent 55%),
+    radial-gradient(circle at 0 100%, rgba(255, 0, 107, 0.65), transparent 60%),
+    radial-gradient(circle at 100% 0, rgba(0, 102, 255, 0.7), transparent 60%);
+  box-shadow:
+    0 32px 80px rgba(0, 0, 0, 0.95),
+    0 0 0 1px rgba(0, 0, 0, 0.9);
+  overflow: hidden;
+}
+
+.frameInner {
+  position: relative;
+  border-radius: calc(var(--radius-xxl) - 1px);
+  background:
+    radial-gradient(circle at 0 0, rgba(255, 255, 255, 0.08), transparent 50%),
+    linear-gradient(145deg, rgba(2, 0, 12, 0.96), rgba(0, 0, 0, 0.98));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(24px);
+  padding: 18px 18px 18px;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.frameInner::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 0 0, rgba(255, 255, 255, 0.12), transparent 55%),
+    radial-gradient(circle at 100% 0, rgba(255, 0, 107, 0.34), transparent 60%),
+    radial-gradient(circle at 100% 100%, rgba(0, 102, 255, 0.42), transparent 60%);
+  mix-blend-mode: screen;
+  opacity: 0.6;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.chrome {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 18px;
+  gap: 14px;
+}
+
+.chromeLeft {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.windowDots {
+  display: flex;
+  gap: 7px;
+}
+
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #2b2b2b;
+  box-shadow: 0 0 0 1px #000;
+}
+
+.red {
+  background: #ff5f57;
+}
+
+.amber {
+  background: #febc2e;
+}
+
+.green {
+  background: #28c840;
+}
+
+.chromeTitle {
+  font-size: 12px;
+  color: var(--br-text-subtle);
+}
+
+.chromePill {
+  padding: 5px 11px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.86);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.chromePillSwatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 7px;
+  background: var(--br-grad-full);
+  box-shadow: 0 0 0 1px #000;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: 22px;
+  padding: 4px 4px 2px;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .hero {
+    order: -1;
+  }
+}
+
+.authCard {
+  background:
+    radial-gradient(circle at 0 0, rgba(255, 255, 255, 0.09), transparent 55%),
+    radial-gradient(circle at 100% 0, rgba(255, 0, 107, 0.32), transparent 60%),
+    radial-gradient(circle at 100% 100%, rgba(0, 102, 255, 0.24), transparent 65%),
+    linear-gradient(155deg, rgba(5, 5, 12, 0.98), rgba(1, 1, 6, 0.99));
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  box-shadow:
+    0 22px 48px rgba(0, 0, 0, 0.92),
+    0 0 0 1px rgba(0, 0, 0, 0.95);
+  padding: 20px 20px 16px;
+  position: relative;
+  overflow: hidden;
+}
+
+.brandLockup {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.brandMark {
+  width: 38px;
+  height: 38px;
+  border-radius: 14px;
+  padding: 1px;
+  background: #000;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.18), 0 14px 28px rgba(0, 0, 0, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.brandMarkInner {
+  width: 100%;
+  height: 100%;
+  border-radius: 12px;
+  background: var(--br-grad-full);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 800;
+  font-size: 14px;
+  letter-spacing: 0.04em;
+  color: #000;
+}
+
+.brandMarkInner span {
+  background: #000;
+  padding: 2px 6px;
+  border-radius: 999px;
+  font-size: 10px;
+}
+
+.brandTextTitle {
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.brandTextSub {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: var(--br-text-faint);
+}
+
+.authTitle {
+  font-size: 22px;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  margin-bottom: 4px;
+}
+
+.authSubtitle {
+  font-size: 12px;
+  color: var(--br-text-subtle);
+  margin-bottom: 14px;
+  max-width: 420px;
+}
+
+.authCard form {
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+  margin-top: 2px;
+}
+
+.fieldLabelRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 11px;
+  color: var(--br-text-subtle);
+  margin-bottom: 4px;
+}
+
+.fieldHint {
+  color: var(--br-text-faint);
+  font-size: 10px;
+}
+
+.field {
+  background:
+    radial-gradient(circle at 0 0, rgba(255, 255, 255, 0.06), transparent 60%),
+    #020208;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  padding: 10px 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.95),
+    0 10px 22px rgba(0, 0, 0, 0.9);
+}
+
+.field input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--br-text);
+  font-size: 13px;
+  font-family: var(--font-sans);
+}
+
+.field input::placeholder {
+  color: var(--br-text-faint);
+}
+
+.fieldPrefix {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--br-text-faint);
+}
+
+.fieldIcon {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: radial-gradient(circle, #ff006b, #7700ff);
+  box-shadow: 0 0 0 1px #000;
+}
+
+.actionsRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  margin-top: 6px;
+  margin-bottom: 4px;
+  font-size: 11px;
+}
+
+.remember {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--br-text-subtle);
+}
+
+.remember input[type='checkbox'] {
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  background: #020006;
+  accent-color: #ff006b;
+}
+
+.linkInline {
+  color: var(--br-text-subtle);
+  text-decoration: none;
+}
+
+.linkInline:hover {
+  text-decoration: underline;
+}
+
+.primaryButton {
+  margin-top: 6px;
+  border: none;
+  outline: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 11px 16px;
+  border-radius: 999px;
+  background: var(--br-grad-full);
+  color: #000;
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow:
+    0 0 0 1px #000,
+    0 18px 38px rgba(0, 0, 0, 0.96);
+  transition: transform 0.08s ease-out, box-shadow 0.08s ease-out, filter 0.08s ease-out;
+}
+
+.kbd {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  background: rgba(0, 0, 0, 0.14);
+  padding: 2px 6px;
+  border-radius: 999px;
+}
+
+.primaryButton:hover {
+  filter: brightness(1.06);
+  transform: translateY(-1px);
+  box-shadow: 0 22px 44px rgba(0, 0, 0, 0.98);
+}
+
+.primaryButton:active {
+  transform: translateY(0);
+  box-shadow: 0 12px 26px rgba(0, 0, 0, 0.9);
+}
+
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 10px;
+  color: var(--br-text-faint);
+  margin: 12px 0 10px;
+}
+
+.dividerLine {
+  flex: 1;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.25), transparent);
+}
+
+.noticeList {
+  list-style: disc;
+  padding-left: 20px;
+  margin: 0;
+  color: var(--br-text-subtle);
+  display: grid;
+  gap: 6px;
+  font-size: 11px;
+}
+
+.hero {
+  position: relative;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.06), transparent 45%),
+    radial-gradient(circle at 100% 0, rgba(255, 0, 107, 0.22), transparent 55%),
+    radial-gradient(circle at 100% 100%, rgba(0, 102, 255, 0.28), transparent 60%),
+    linear-gradient(155deg, rgba(6, 4, 20, 0.96), rgba(3, 1, 10, 0.96));
+  border-radius: var(--radius-xl);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  box-shadow:
+    0 22px 48px rgba(0, 0, 0, 0.9),
+    0 0 0 1px rgba(0, 0, 0, 0.95);
+  padding: 24px;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.heroGlow {
+  position: absolute;
+  inset: -20%;
+  background: radial-gradient(circle, rgba(255, 0, 107, 0.12), transparent 55%);
+  filter: blur(18px);
+  z-index: -1;
+}
+
+.heroBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  font-size: 11px;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+
+.heroTitle {
+  margin: 14px 0 6px;
+  font-size: 24px;
+  letter-spacing: -0.03em;
+}
+
+.heroSubtitle {
+  font-size: 13px;
+  color: var(--br-text-subtle);
+  max-width: 560px;
+  margin-bottom: 16px;
+}
+
+.heroGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+.heroCard {
+  background:
+    radial-gradient(circle at 0 0, rgba(255, 255, 255, 0.05), transparent 55%),
+    linear-gradient(145deg, rgba(9, 9, 15, 0.9), rgba(2, 1, 8, 0.9));
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 16px;
+  padding: 14px 12px 12px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.7);
+}
+
+.cardLabel {
+  font-size: 11px;
+  color: var(--br-text-faint);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+
+.cardValue {
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 4px;
+}
+
+.cardMeta {
+  font-size: 11px;
+  color: var(--br-text-subtle);
+}
+
+@media (max-width: 640px) {
+  .loginRoot {
+    padding: 18px 12px;
+  }
+
+  .chrome {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .actionsRow {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .primaryButton {
+    width: 100%;
+  }
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { FormEvent, useEffect } from 'react';
+import styles from './LoginPage.module.css';
+
+export default function LoginPage() {
+  useEffect(() => {
+    const bodyClass = 'br-login-body';
+    document.body.classList.add(bodyClass);
+    return () => {
+      document.body.classList.remove(bodyClass);
+    };
+  }, []);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const payload = Object.fromEntries(formData.entries());
+    // eslint-disable-next-line no-console
+    console.log('Login form submitted', payload);
+  };
+
+  return (
+    <div className={styles.loginRoot}>
+      <div className={styles.frameShell}>
+        <div className={styles.frameInner}>
+          <div className={styles.chrome}>
+            <div className={styles.chromeLeft}>
+              <div className={styles.windowDots} aria-hidden>
+                <span className={`${styles.dot} ${styles.red}`} />
+                <span className={`${styles.dot} ${styles.amber}`} />
+                <span className={`${styles.dot} ${styles.green}`} />
+              </div>
+              <div className={styles.chromeTitle}>BlackRoad Operator Shell</div>
+            </div>
+            <div className={styles.chromePill}>
+              <span className={styles.chromePillSwatch} />
+              <span>Operator session</span>
+            </div>
+          </div>
+
+          <div className={styles.layout}>
+            <section className={styles.authCard}>
+              <div className={styles.brandLockup}>
+                <div className={styles.brandMark}>
+                  <div className={styles.brandMarkInner}>
+                    <span>BR</span>
+                  </div>
+                </div>
+                <div>
+                  <div className={styles.brandTextTitle}>BlackRoad OS</div>
+                  <div className={styles.brandTextSub}>Operator login</div>
+                </div>
+              </div>
+
+              <h1 className={styles.authTitle}>Authenticate session</h1>
+              <p className={styles.authSubtitle}>
+                Secure access to the BlackRoad operator console. Use your organization credentials to
+                continue.
+              </p>
+
+              <form onSubmit={handleSubmit}>
+                <div>
+                  <div className={styles.fieldLabelRow}>
+                    <label htmlFor="email">Email</label>
+                    <span className={styles.fieldHint}>workspace identity</span>
+                  </div>
+                  <div className={styles.field}>
+                    <span className={styles.fieldPrefix}>br://</span>
+                    <input
+                      id="email"
+                      name="email"
+                      type="email"
+                      autoComplete="username"
+                      placeholder="operator@blackroad.systems"
+                      required
+                      aria-label="Email"
+                    />
+                    <span className={styles.fieldIcon} aria-hidden />
+                  </div>
+                </div>
+
+                <div>
+                  <div className={styles.fieldLabelRow}>
+                    <label htmlFor="password">Password</label>
+                    <span className={styles.fieldHint}>encrypted</span>
+                  </div>
+                  <div className={styles.field}>
+                    <span className={styles.fieldPrefix}>***</span>
+                    <input
+                      id="password"
+                      name="password"
+                      type="password"
+                      autoComplete="current-password"
+                      placeholder="Enter passphrase"
+                      required
+                      aria-label="Password"
+                    />
+                    <span className={styles.fieldIcon} aria-hidden />
+                  </div>
+                </div>
+
+                <div className={styles.actionsRow}>
+                  <label className={styles.remember}>
+                    <input type="checkbox" name="remember" value="on" />
+                    <span>Keep me signed in</span>
+                  </label>
+                  <a className={styles.linkInline} href="#">
+                    Forgot access?
+                  </a>
+                </div>
+
+                <button type="submit" className={styles.primaryButton}>
+                  Authenticate
+                  <span className={styles.kbd}>↵</span>
+                </button>
+              </form>
+
+              <div className={styles.divider}>
+                <span className={styles.dividerLine} />
+                <span>Operator notices</span>
+                <span className={styles.dividerLine} />
+              </div>
+
+              <ul className={styles.noticeList}>
+                <li>All sessions monitored and audit logged.</li>
+                <li>Use hardware key for elevated workflows.</li>
+                <li>Contact security if you suspect compromise.</li>
+              </ul>
+            </section>
+
+            <section className={styles.hero}>
+              <div className={styles.heroGlow} aria-hidden />
+              <div className={styles.heroBadge}>BlackRoad OS</div>
+              <h2 className={styles.heroTitle}>Operator control surface</h2>
+              <p className={styles.heroSubtitle}>
+                Execute trusted workflows across the BlackRoad stack. Resilient, auditable, and ready
+                for critical operations.
+              </p>
+              <div className={styles.heroGrid}>
+                <div className={styles.heroCard}>
+                  <div className={styles.cardLabel}>Stack Health</div>
+                  <div className={styles.cardValue}>All systems stable</div>
+                  <p className={styles.cardMeta}>Live telemetry with redundancy</p>
+                </div>
+                <div className={styles.heroCard}>
+                  <div className={styles.cardLabel}>Access Tier</div>
+                  <div className={styles.cardValue}>Ops / Privileged</div>
+                  <p className={styles.cardMeta}>Key-based escalation required</p>
+                </div>
+                <div className={styles.heroCard}>
+                  <div className={styles.cardLabel}>Regions</div>
+                  <div className={styles.cardValue}>6 active zones</div>
+                  <p className={styles.cardMeta}>Autoscaling with ledger sync</p>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add the BlackRoad OS operator login page at /login using a scoped CSS module and gradients from the design
- apply a route-specific body class to remove shared chrome and allow full-width framing for the login shell
- implement presentational form handling with required accessibility attributes and console logging

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69210ab845d083298211da608527cbc9)