### PR TITLE
Add brand tokens and app shell layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,23 +1,5 @@
-:root {
-  color-scheme: dark;
-  --bg: #0b0c10;
-  --panel: #12141b;
-  --accent: #72e4a2;
-  --muted: #9ba3af;
-  --text: #e5e7eb;
-  --border: #1f2937;
-  font-family: 'Inter', system-ui, -apple-system, sans-serif;
-}
-
 * {
   box-sizing: border-box;
-}
-
-body {
-  margin: 0;
-  min-height: 100vh;
-  background: radial-gradient(120% 120% at 50% 15%, rgba(114, 228, 162, 0.08), transparent 50%), var(--bg);
-  color: var(--text);
 }
 
 a {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 import './globals.css';
+import './styles/brand.css';
+import { AppShell } from '@/components/layout/AppShell';
 import { Header } from '@/components/layout/Header';
 import { Footer } from '@/components/layout/Footer';
 
@@ -17,9 +19,11 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <Header />
-        <main>{children}</main>
-        <Footer />
+        <AppShell>
+          <Header />
+          <main>{children}</main>
+          <Footer />
+        </AppShell>
       </body>
     </html>
   );

--- a/app/login/page.module.css
+++ b/app/login/page.module.css
@@ -1,0 +1,307 @@
+.brLoginLayout {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  color: var(--br-text);
+}
+
+.chromeBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: var(--br-radius-xl);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background:
+    linear-gradient(90deg, rgba(255, 0, 107, 0.18), rgba(0, 102, 255, 0.18)),
+    var(--br-shell);
+  box-shadow: 0 10px 38px rgba(0, 0, 0, 0.35);
+}
+
+.identity {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.brandGlyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: var(--br-grad-full);
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  color: #05010f;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+}
+
+.chromeLabel {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--br-text);
+}
+
+.chromeMeta {
+  margin: 0;
+  color: var(--br-text-subtle);
+  font-size: 0.9rem;
+}
+
+.chromeStatus {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--br-text-subtle);
+  font-size: 0.95rem;
+}
+
+.statusPulse {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--br-warm);
+  box-shadow: 0 0 0 6px rgba(255, 107, 0, 0.15);
+}
+
+.contentGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 18px;
+  align-items: stretch;
+}
+
+.authCard {
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0.01)),
+    var(--br-shell);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--br-radius-xl);
+  padding: 22px;
+  box-shadow:
+    0 28px 60px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(255, 255, 255, 0.03);
+}
+
+.cardHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.eyebrow {
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.85rem;
+  color: var(--br-text-subtle);
+}
+
+.title {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--br-text-subtle);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.95rem;
+  color: var(--br-text);
+}
+
+.field span {
+  color: var(--br-text-subtle);
+}
+
+.field input {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(19, 19, 31, 0.7);
+  color: var(--br-text);
+  font-size: 1rem;
+  transition: border-color 120ms ease, box-shadow 120ms ease, background 120ms ease;
+}
+
+.field input:focus {
+  outline: none;
+  border-color: rgba(0, 102, 255, 0.5);
+  box-shadow: 0 0 0 4px rgba(0, 102, 255, 0.15);
+  background: rgba(19, 19, 31, 0.9);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 6px;
+}
+
+.primaryButton,
+.secondaryButton {
+  border-radius: 12px;
+  padding: 12px 16px;
+  font-weight: 700;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 150ms ease, border-color 120ms ease;
+}
+
+.primaryButton {
+  background: var(--br-grad-br);
+  color: #05010f;
+  box-shadow: 0 16px 40px rgba(255, 0, 107, 0.3);
+}
+
+.primaryButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 44px rgba(255, 0, 107, 0.38);
+}
+
+.secondaryButton {
+  background: transparent;
+  color: var(--br-text);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.secondaryButton:hover {
+  transform: translateY(-1px);
+  border-color: rgba(0, 102, 255, 0.5);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+}
+
+.helpRow {
+  margin-top: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  color: var(--br-text-subtle);
+}
+
+.helpLabel {
+  font-size: 0.95rem;
+}
+
+.link {
+  color: var(--br-cyber-blue);
+  font-weight: 700;
+}
+
+.heroPanel {
+  position: relative;
+  padding: 24px;
+  border-radius: var(--br-radius-xl);
+  background:
+    radial-gradient(circle at 0 0, rgba(255, 255, 255, 0.08), transparent 50%),
+    var(--br-grad-full);
+  color: #05010f;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow:
+    0 24px 60px rgba(0, 0, 0, 0.5),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+  overflow: hidden;
+}
+
+.heroPanel::after {
+  content: '';
+  position: absolute;
+  inset: 14px;
+  border-radius: calc(var(--br-radius-xl) - 12px);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+.heroBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 16px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.72);
+  color: #fff;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+}
+
+.heroCopy {
+  margin-top: 14px;
+  max-width: 520px;
+  color: #0b0b12;
+}
+
+.heroCopy h2 {
+  margin: 0 0 8px;
+  color: #04040a;
+}
+
+.heroCopy p {
+  margin: 0 0 12px;
+  color: #0b0b12;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.heroList {
+  margin: 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: #0b0b12;
+  font-weight: 600;
+}
+
+.statusText,
+.chromeMeta,
+.subtitle,
+.helpRow {
+  font-family: var(--br-font-sans);
+}
+
+@media (max-width: 960px) {
+  .contentGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .brLoginLayout {
+    gap: 14px;
+  }
+}
+
+@media (max-width: 640px) {
+  .chromeBar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .actions {
+    width: 100%;
+  }
+
+  .primaryButton,
+  .secondaryButton {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,73 @@
+import styles from './page.module.css';
+
+export default function LoginPage() {
+  return (
+    <section className={styles.brLoginLayout}>
+      <div className={styles.chromeBar}>
+        <div className={styles.identity}>
+          <div className={styles.brandGlyph}>BR·OS</div>
+          <div>
+            <p className={styles.chromeLabel}>Operator Access</p>
+            <p className={styles.chromeMeta}>Secure ingress · Tier 1 controls</p>
+          </div>
+        </div>
+        <div className={styles.chromeStatus}>
+          <span className={styles.statusPulse} aria-hidden />
+          <span className={styles.statusText}>Systems nominal</span>
+        </div>
+      </div>
+
+      <div className={styles.contentGrid}>
+        <div className={styles.authCard}>
+          <div className={styles.cardHeader}>
+            <p className={styles.eyebrow}>BlackRoad Operator</p>
+            <h1 className={styles.title}>Login</h1>
+            <p className={styles.subtitle}>Use your BR·OS credentials to continue.</p>
+          </div>
+
+          <form className={styles.form} action="#" method="post">
+            <label className={styles.field}>
+              <span>Access ID</span>
+              <input type="email" name="email" placeholder="you@blackroad.systems" />
+            </label>
+            <label className={styles.field}>
+              <span>Passphrase</span>
+              <input type="password" name="password" placeholder="••••••••••" />
+            </label>
+            <div className={styles.actions}>
+              <button type="submit" className={styles.primaryButton}>
+                Sign in
+              </button>
+              <button type="button" className={styles.secondaryButton}>
+                Request access
+              </button>
+            </div>
+          </form>
+
+          <div className={styles.helpRow}>
+            <span className={styles.helpLabel}>Need help?</span>
+            <a className={styles.link} href="mailto:ops@blackroad.systems">
+              Contact operations
+            </a>
+          </div>
+        </div>
+
+        <div className={styles.heroPanel}>
+          <div className={styles.heroBadge}>BR·OS</div>
+          <div className={styles.heroCopy}>
+            <h2>Operational control</h2>
+            <p>
+              Enforce least-privilege access to the systems that keep BlackRoad OS running. Secure
+              tunnels, full audit trails, and tiered access all live here.
+            </p>
+            <ul className={styles.heroList}>
+              <li>Unified operator ingress with adaptive authentication</li>
+              <li>Live telemetry overlays with anomaly detection</li>
+              <li>Role-aware controls scoped to your responsibilities</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/styles/brand.css
+++ b/app/styles/brand.css
@@ -1,0 +1,76 @@
+:root {
+  color-scheme: dark;
+  --br-sunrise: #FF9D00;
+  --br-warm: #FF6B00;
+  --br-hot-pink: #FF0066;
+  --br-magenta: #FF006B;
+  --br-deep-magenta: #D600AA;
+  --br-purple: #7700FF;
+  --br-cyber-blue: #0066FF;
+
+  --br-grad-full: linear-gradient(
+    135deg,
+    #FF9D00 0%,
+    #FF6B00 16%,
+    #FF0066 32%,
+    #FF006B 48%,
+    #D600AA 64%,
+    #7700FF 80%,
+    #0066FF 100%
+  );
+  --br-grad-br: linear-gradient(
+    180deg,
+    #FF9D00 0%,
+    #FF6B00 25%,
+    #FF0066 75%,
+    #FF006B 100%
+  );
+  --br-grad-os: linear-gradient(
+    180deg,
+    #FF006B 0%,
+    #D600AA 25%,
+    #7700FF 75%,
+    #0066FF 100%
+  );
+
+  --br-bg: #020008;
+  --br-bg-alt: #05010f;
+  --br-shell: rgba(4, 4, 10, 0.96);
+  --br-surface: #0b0b12;
+  --br-surface-alt: #13131f;
+
+  --br-text: #ffffff;
+  --br-text-subtle: rgba(255, 255, 255, 0.76);
+  --br-text-faint: rgba(255, 255, 255, 0.55);
+
+  --br-radius-lg: 20px;
+  --br-radius-xl: 26px;
+  --br-radius-xxl: 32px;
+
+  --br-font-sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", system-ui, sans-serif;
+  --br-font-mono: "JetBrains Mono", "SF Mono", ui-monospace, Menlo, monospace;
+
+  --bg: var(--br-bg);
+  --panel: var(--br-surface);
+  --accent: #72e4a2;
+  --muted: rgba(255, 255, 255, 0.76);
+  --text: var(--br-text);
+  --border: rgba(255, 255, 255, 0.12);
+}
+
+html,
+body,
+#__next {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: var(--br-font-sans);
+  color: var(--br-text);
+  background:
+    radial-gradient(circle at top, #1a1026 0, #05000b 45%, #000 100%),
+    radial-gradient(circle at 0 0, rgba(255,255,255,0.05) 0, transparent 55%),
+    radial-gradient(circle at 100% 100%, rgba(0,102,255,0.2) 0, transparent 55%);
+  -webkit-font-smoothing: antialiased;
+}

--- a/src/components/layout/AppShell.module.css
+++ b/src/components/layout/AppShell.module.css
@@ -1,0 +1,43 @@
+.brAppRoot {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+}
+
+.brFrameShell {
+  position: relative;
+  width: 100%;
+  max-width: 1120px;
+  border-radius: var(--br-radius-xxl);
+  padding: 1px;
+  background:
+    radial-gradient(circle at 0 0, rgba(255, 255, 255, 0.18), transparent 55%),
+    radial-gradient(circle at 0 100%, rgba(255, 0, 107, 0.65), transparent 60%),
+    radial-gradient(circle at 100% 0, rgba(0, 102, 255, 0.7), transparent 60%);
+  box-shadow:
+    0 32px 80px rgba(0, 0, 0, 0.95),
+    0 0 0 1px rgba(0, 0, 0, 0.9);
+  overflow: hidden;
+}
+
+.brFrameInner {
+  position: relative;
+  border-radius: calc(var(--br-radius-xxl) - 1px);
+  background:
+    radial-gradient(circle at 0 0, rgba(255, 255, 255, 0.08), transparent 50%),
+    linear-gradient(145deg, rgba(2, 0, 12, 0.96), rgba(0, 0, 0, 0.98));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  backdrop-filter: blur(24px);
+  padding: 18px;
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.brContent {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react';
+import styles from './AppShell.module.css';
+
+interface AppShellProps {
+  children: ReactNode;
+}
+
+export function AppShell({ children }: AppShellProps) {
+  return (
+    <div className={styles.brAppRoot}>
+      <div className={styles.brFrameShell}>
+        <div className={styles.brFrameInner}>
+          <div className={styles.brContent}>{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -57,22 +57,12 @@ p {
   h1 {
     font-size: 2rem;
   }
-  
+
   h2 {
     font-size: 1.5rem;
   }
-  
+
   h3 {
     font-size: 1.25rem;
   }
-}
-
-:root {
-  --br-gradient-start: #ff9d00;
-  --br-gradient-mid: #ff6b00;
-  --br-gradient-hot: #ff0066;
-  --os-gradient-start: #ff006b;
-  --os-gradient-mid: #d600aa;
-  --os-gradient-deep: #7700ff;
-  --os-gradient-end: #0066ff;
 }


### PR DESCRIPTION
## Summary
- add a brand token stylesheet with BR·OS colors, gradients, typography, and base body styling
- introduce a reusable AppShell wrapper so all pages share the OS shell treatment
- build the /login route to consume the new shell and tokenized styles

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69210caaa2c48329a2615320a9013256)