### PR TITLE
Add health check endpoint and browser health page

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,1 +1,1 @@
-export { GET } from '../../health/route';
+export { GET, dynamic } from '../../health/route';

--- a/app/health/page.tsx
+++ b/app/health/page.tsx
@@ -1,0 +1,5 @@
+export const dynamic = 'force-static';
+
+export default function HealthPage() {
+  return <main>ok</main>;
+}

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -1,8 +1,13 @@
 import { NextResponse } from 'next/server';
 
+export const dynamic = 'force-static';
+
+// NOTE: Add api/health test once test infrastructure is wired up.
 export async function GET() {
   return NextResponse.json({
     status: 'ok',
-    service: 'web'
+    service: 'web',
+    env: process.env.NODE_ENV ?? 'development',
+    timestamp: new Date().toISOString()
   });
 }


### PR DESCRIPTION
## Summary
- add static health JSON handler for `/health` and re-export to `/api/health`
- include environment and timestamp metadata for Railway monitoring
- add lightweight `/health` page for quick manual checks

## Testing
- npm run lint (fails: existing parsing error in app/login/page.tsx)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69211177e5788329a9d4e062f657a441)