### PR TITLE
Ensure brand gradients load globally

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,6 +6,13 @@
   --muted: #9ba3af;
   --text: #e5e7eb;
   --border: #1f2937;
+  --br-gradient-start: #ff9d00;
+  --br-gradient-mid: #ff6b00;
+  --br-gradient-hot: #ff0066;
+  --os-gradient-start: #ff006b;
+  --os-gradient-mid: #d600aa;
+  --os-gradient-deep: #7700ff;
+  --os-gradient-end: #0066ff;
   font-family: 'Inter', system-ui, -apple-system, sans-serif;
 }
 


### PR DESCRIPTION
## Summary
- add brand gradient custom properties to `app/globals.css` so they are available to brand kit styles

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921124f7118832996972f9117e4a3c3)