### PR TITLE
Align Railway build config and health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,20 @@ npm run dev
 npm run build
 npm start
 ```
-Default port is **8080** (configurable via `PORT`).
+Default port is **8080** (configurable via `PORT`). The server binds to `0.0.0.0` and respects `PORT` for Railway compatibility.
+
+### Production Commands (Railway)
+- **Build**: `npm ci && npm run build`
+- **Start**: `npm run start` (uses `$PORT`, defaults to 8080)
+- **Service name**: `blackroad-os-web`
+- **Health**: `GET /health` → `{ "status": "ok", "service": "web" }`
 
 ## Railway Deployment
 
 This application is configured for deployment on [Railway](https://railway.app) using Nixpacks.
 
 - **Nixpacks flow**: `npm ci` → `npm run build` → `npm start` (configured in `railway.json` and `nixpacks.toml`)
-- **Healthcheck**: `/api/health` is used for liveness checks and the app binds to `$PORT` automatically
+- **Healthcheck**: `/health` is used for liveness checks and the app binds to `$PORT` automatically
 - **Environment**: Mirror the values from `.env.example` (including `NEXT_PUBLIC_*` keys) in the Railway dashboard
 
 ### Configuration Files
@@ -88,15 +94,15 @@ This application is configured for deployment on [Railway](https://railway.app) 
    - `NEXT_PUBLIC_PUBLIC_API_URL` - Public API base URL (client-side)
 
 3. **Deploy**: Railway will automatically:
-   - Detect Node.js and use Nixpacks builder
-   - Install dependencies with `npm ci`
-   - Build the application with `npm run build`
-   - Start the server with `npm start`
-   - Monitor health via `/api/health` endpoint
+     - Detect Node.js and use Nixpacks builder
+     - Install dependencies with `npm ci`
+     - Build the application with `npm run build`
+     - Start the server with `npm start`
+     - Monitor health via `/health` endpoint
 
 ### Technical Details
 - **Port**: Automatically assigned by Railway via `$PORT` environment variable
-- **Healthcheck**: `/api/health` (checks every 100 seconds)
+- **Healthcheck**: `/health` (checks every 100 seconds)
 - **Restart Policy**: ON_FAILURE with max 10 retries
 - **Builder**: Nixpacks (Node.js 18)
 
@@ -112,5 +118,5 @@ This application is configured for deployment on [Railway](https://railway.app) 
 - Review logs for any startup errors
 
 ## Notes
-- `/health` is also available and shares the `/api/health` handler.
+- `/health` returns `{ "status": "ok", "service": "web" }` and shares the `/api/health` handler.
 - Status widget on the landing page polls `/api/health` every 15 seconds.

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -2,12 +2,6 @@ import { NextResponse } from 'next/server';
 
 export const dynamic = 'force-static';
 
-// NOTE: Add api/health test once test infrastructure is wired up.
 export async function GET() {
-  return NextResponse.json({
-    status: 'ok',
-    service: 'web',
-    env: process.env.NODE_ENV ?? 'development',
-    timestamp: new Date().toISOString()
-  });
+  return NextResponse.json({ status: 'ok', service: 'web' });
 }

--- a/railway.json
+++ b/railway.json
@@ -2,11 +2,11 @@
   "$schema": "https://railway.app/railway.schema.json",
   "build": {
     "builder": "NIXPACKS",
-    "buildCommand": "npm install && npm run build"
+    "buildCommand": "npm ci && npm run build"
   },
   "deploy": {
     "startCommand": "npm run start",
-    "healthcheckPath": "/api/health",
+    "healthcheckPath": "/health",
     "healthcheckTimeout": 100,
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10


### PR DESCRIPTION
## Summary
- Standardize the /health route response for the web service
- Update Railway build and healthcheck settings for the blackroad-os-web service
- Document production build/start commands and health probe expectations

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69219618d8b88329ab83323cf5dda78c)