### PR TITLE
Simplify health endpoint response

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -3,9 +3,7 @@ import { NextResponse } from 'next/server';
 export async function GET() {
   const body = {
     status: 'ok',
-    service: 'web',
-    timestamp: new Date().toISOString(),
-    env: process.env.NODE_ENV ?? 'development'
+    service: 'web'
   };
 
   return NextResponse.json(body, { status: 200 });


### PR DESCRIPTION
## Summary
- adjust health API response to return only status and service fields

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922534ab3448329a18586edd87e0f02)