### PR TITLE
Create marketing site structure and pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,122 +1,46 @@
 # BlackRoad OS – Web
 
-Public-facing website and entrypoint for the BlackRoad Operating System. Built with Next.js (App Router) and React.
+Public-facing marketing site for BlackRoad OS, the AI-first operating system that lets one human orchestrator direct 10,000+ virtual employees across regulated domains.
 
-## Tech Stack
-- Next.js 14 (App Router)
-- React 18
-- TypeScript
+## What this repo is
+- Marketing and storytelling surface for BlackRoad OS (not the Prism admin console or API).
+- Built with Next.js 14 (App Router) and React 18 using TypeScript.
+- Includes pages for product, pricing, regulated industries, about, contact, and legal stubs.
 
-## Quickstart
-1. Copy environment defaults and tailor them for your workspace:
-   ```bash
-   cp .env.example .env.local
-   # Update OS_ROOT, SERVICE_BASE_URL, CORE_API_URL, PUBLIC_* URLs, and NEXT_PUBLIC_* values
-   ```
-   Both server-side variables (`OS_ROOT`, `SERVICE_BASE_URL`, `CORE_API_URL`, `PUBLIC_*`) and client-embedded variables (`NEXT_PUBLIC_*`) must be set so configuration resolves correctly at build and runtime.
-2. Install dependencies and run the local dev server:
+## Getting started
+1. Install dependencies and run the dev server:
    ```bash
    npm install
    npm run dev
    ```
-   Visit the marketing page at [http://localhost:3000](http://localhost:3000) and confirm API responses at `/api/health`, `/api/info`, and `/api/version`.
+   Visit [http://localhost:3000](http://localhost:3000).
 
-## Key Endpoints
-- `/` — marketing landing page with system links and live health widget
-- `/api/health` — service health probe
-- `/api/info` — service metadata and base URLs
-- `/api/version` — build and version metadata
-- `/api/debug-env` — safe environment snapshot for diagnostics
+2. Build and start in production mode:
+   ```bash
+   npm run build
+   npm run start
+   ```
+   Default port is **8080** (configurable via `PORT`). The server binds to `0.0.0.0`.
 
 ## Configuration
-Runtime configuration is centralized in `src/config/serviceConfig.ts` and `src/config.ts`.
+Key environment variables (see `.env.example`):
+- `NEXT_PUBLIC_DOCS_URL` — destination for “Docs” links.
+- `NEXT_PUBLIC_CONSOLE_URL` — console link used on legacy routes.
+- `NEXT_PUBLIC_CORE_API_URL` and `NEXT_PUBLIC_PUBLIC_API_URL` — surfaced in telemetry widgets.
+- `SERVICE_BASE_URL`, `OS_ROOT`, and other `PUBLIC_*` keys — used by runtime config and health endpoints.
 
-Environment variables (see `.env.example`):
-- `OS_ROOT` — BlackRoad OS root URL
-- `SERVICE_BASE_URL` — Public base URL for this web service
-- `NEXT_PUBLIC_OS_ROOT` — Client-exposed OS root
-- `NEXT_PUBLIC_SERVICE_ID` — Service identifier (`web`)
-- `NEXT_PUBLIC_SERVICE_NAME` — Human-readable service name
-- `NEXT_PUBLIC_CONSOLE_URL` — Console link
-- `NEXT_PUBLIC_DOCS_URL` — Documentation link
-- `NEXT_PUBLIC_CORE_API_URL` — Core API base URL
-- `NEXT_PUBLIC_PUBLIC_API_URL` — Public API base URL
+## Deployment (Railway)
+- Build: `npm ci && npm run build`
+- Start: `npm run start` (respects `$PORT`, defaults to 8080)
+- Health: `/health` or `/api/health`
 
-## Local Development
-```bash
-npm install
-npm run dev
-```
+## Repository structure
+- `/app` — Next.js routes (marketing pages, legacy console/status routes, API handlers)
+- `/src/components` — shared UI (layout, marketing blocks, status widgets)
+- `/src/lib` — helpers such as navigation routes
+- `/docs/site-structure.md` — notes on pages and navigation
 
-## Build & Start
-```bash
-npm run build
-npm start
-```
-Default port is **8080** (configurable via `PORT`). The server binds to `0.0.0.0` and respects `PORT` for Railway compatibility.
-
-### Production Commands (Railway)
-- **Build**: `npm ci && npm run build`
-- **Start**: `npm run start` (uses `$PORT`, defaults to 8080)
-- **Service name**: `blackroad-os-web`
-- **Health**: `GET /health` → `{ "status": "ok", "service": "web" }`
-
-## Railway Deployment
-
-This application is configured for deployment on [Railway](https://railway.app) using Nixpacks.
-
-- **Nixpacks flow**: `npm ci` → `npm run build` → `npm start` (configured in `railway.json` and `nixpacks.toml`)
-- **Healthcheck**: `/health` is used for liveness checks and the app binds to `$PORT` automatically
-- **Environment**: Mirror the values from `.env.example` (including `NEXT_PUBLIC_*` keys) in the Railway dashboard
-
-### Configuration Files
-- `railway.json` - Railway service configuration (healthcheck, restart policy)
-- `nixpacks.toml` - Build configuration for Nixpacks builder
-- `Dockerfile` - Alternative Docker-based deployment (optional)
-
-### Deployment Steps
-
-1. **Connect Repository**: Link your GitHub repository to Railway
-2. **Configure Environment Variables**: Set all variables from `.env.example` in the Railway dashboard:
-   - `NODE_ENV` - Set to `production`
-   - `OS_ROOT` - Your BlackRoad OS root URL
-   - `SERVICE_BASE_URL` - Public URL for this web service
-   - `CORE_API_URL` - Core API base URL
-   - `PUBLIC_WEB_URL` - Public web URL
-   - `PUBLIC_CONSOLE_URL` - Console link
-   - `PUBLIC_DOCS_URL` - Documentation link
-   - `NEXT_PUBLIC_OS_ROOT` - Client-exposed OS root
-   - `NEXT_PUBLIC_SERVICE_ID` - Service identifier (e.g., `web`)
-   - `NEXT_PUBLIC_SERVICE_NAME` - Human-readable service name
-   - `NEXT_PUBLIC_CONSOLE_URL` - Console link (client-side)
-   - `NEXT_PUBLIC_DOCS_URL` - Documentation link (client-side)
-   - `NEXT_PUBLIC_CORE_API_URL` - Core API base URL (client-side)
-   - `NEXT_PUBLIC_PUBLIC_API_URL` - Public API base URL (client-side)
-
-3. **Deploy**: Railway will automatically:
-     - Detect Node.js and use Nixpacks builder
-     - Install dependencies with `npm ci`
-     - Build the application with `npm run build`
-     - Start the server with `npm start`
-     - Monitor health via `/health` endpoint
-
-### Technical Details
-- **Port**: Automatically assigned by Railway via `$PORT` environment variable
-- **Healthcheck**: `/health` (checks every 100 seconds)
-- **Restart Policy**: ON_FAILURE with max 10 retries
-- **Builder**: Nixpacks (Node.js 18)
-
-### Troubleshooting
-
-**Build fails with "Missing required environment variable"**:
-- Ensure all required environment variables are set in Railway dashboard before deployment
-- The application requires environment variables during build time for Next.js
-
-**Health check fails**:
-- Verify the application is binding to `0.0.0.0` (not just `localhost`)
-- Check that `PORT` environment variable is being used correctly
-- Review logs for any startup errors
-
-## Notes
-- `/health` returns `{ "status": "ok", "service": "web" }` and shares the `/api/health` handler.
-- Status widget on the landing page polls `/api/health` every 15 seconds.
+## Future enhancements
+- Add richer SEO/OpenGraph metadata per page.
+- Wire the contact form to a backend and add analytics.
+- Expand localization and accessibility coverage.

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,52 @@
+import type { Metadata } from 'next';
+import styles from '../marketing.module.css';
+
+export const metadata: Metadata = {
+  title: 'About | BlackRoad OS',
+  description: 'Why BlackRoad OS exists and how one orchestrator directs thousands of AI agents with compliance-first design.'
+};
+
+export default function AboutPage() {
+  return (
+    <div>
+      <section className={`section ${styles.pageHeader}`}>
+        <div className="section-inner">
+          <div className={styles.tagRow}>
+            <span className={styles.pill}>About</span>
+            <span className={styles.pill}>Story</span>
+          </div>
+          <h1 className="section-title">We build leverage without abandoning oversight</h1>
+          <p className={styles.lead}>
+            BlackRoad OS was created so regulated operators can scale with AI safely. We combine ledger-native journaling, policy-driven orchestration, and a console designed for humans-in-the-loop.
+          </p>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="section-inner card-grid">
+          <div className="card">
+            <h3>Why we exist</h3>
+            <p className="muted">
+              Modern enterprises need automation, but they cannot trade away compliance or auditability. We make it possible to deploy thousands of AI agents with controls that satisfy finance, legal, and security leaders.
+            </p>
+          </div>
+          <div className="card">
+            <h3>Operating philosophy</h3>
+            <p className="muted">
+              We do not replace humans in critical roles—we magnify their leverage. The orchestrator approves thresholds, sets policy, and remains accountable while agents execute repeatable work.
+            </p>
+          </div>
+          <div className="card">
+            <h3>What comes next</h3>
+            <p className="muted">
+              Expect deeper analytics, more compliance templates, and richer automations across finance and legal. Multi-language experiences and first-party contact workflows are on the roadmap.
+            </p>
+            <p className="muted">
+              TODO: Add OpenGraph metadata, analytics integrations, and localization for global teams.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from 'next';
+import { ContactForm } from '@/components/ContactForm';
+import styles from '../marketing.module.css';
+
+export const metadata: Metadata = {
+  title: 'Contact | BlackRoad OS',
+  description: 'Request early access to BlackRoad OS and tell us what you want to automate.'
+};
+
+export default function ContactPage() {
+  return (
+    <div>
+      <section className={`section ${styles.pageHeader}`}>
+        <div className="section-inner">
+          <div className={styles.tagRow}>
+            <span className={styles.pill}>Contact</span>
+            <span className={styles.pill}>Early access</span>
+          </div>
+          <h1 className="section-title">Tell us what you want to automate</h1>
+          <p className={styles.lead}>Let us know about your company, your industry, and the workflows you want governed by BlackRoad OS.</p>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="section-inner">
+          <ContactForm />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,12 +4,163 @@
   box-sizing: border-box;
 }
 
+:root {
+  color-scheme: dark;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(120% 120% at 50% 15%, rgba(114, 228, 162, 0.08), transparent 50%), var(--bg);
+  background:
+    radial-gradient(160% 120% at 20% 20%, rgba(255, 0, 102, 0.14), transparent 45%),
+    radial-gradient(120% 120% at 80% 0%, rgba(0, 102, 255, 0.18), transparent 40%),
+    radial-gradient(80% 80% at 50% 10%, rgba(255, 157, 0, 0.12), transparent 35%),
+    var(--bg);
   color: var(--text);
-  font-family: var(--br-font-sans);
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+main {
+  width: 100%;
+}
+
+button {
+  font-family: inherit;
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 1.5rem;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.accent {
+  color: var(--accent);
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.section {
+  padding: 72px 0;
+  position: relative;
+}
+
+.section::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  opacity: 0.35;
+}
+
+.section-inner {
+  width: min(1200px, 92vw);
+  margin: 0 auto;
+  position: relative;
+  z-index: 1;
+}
+
+.section-title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin-bottom: 0.5rem;
+}
+
+.section-subtitle {
+  color: var(--muted);
+  max-width: 720px;
+  line-height: 1.6;
+}
+
+.cta-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.35rem;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--br-grad-full);
+  color: #0a0a0f;
+  font-weight: 700;
+  transition: transform 180ms ease, box-shadow 200ms ease, opacity 180ms ease;
+  box-shadow: 0 16px 40px rgba(255, 0, 102, 0.28);
+}
+
+.cta-button:hover {
+  transform: translateY(-2px) scale(1.01);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.45);
+}
+
+.cta-button.secondary {
+  background: transparent;
+  color: var(--text);
+  border-color: rgba(255, 255, 255, 0.12);
+  box-shadow: none;
+}
+
+.cta-button.secondary:hover {
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--text);
+  font-size: 0.85rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.card {
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+.card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.list-disc {
+  list-style: disc;
+  margin: 0.75rem 0 0 1.5rem;
+  color: var(--muted);
+  line-height: 1.6;
 }
 
 body.br-login-body {
@@ -27,35 +178,16 @@ body.br-login-body footer {
   display: none;
 }
 
-a {
-  color: inherit;
-  text-decoration: none;
+input.panel,
+textarea.panel {
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(0, 0, 0, 0.35);
+  color: var(--text);
+  border-radius: 12px;
+  padding: 0.75rem 0.85rem;
 }
 
-main {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 2.5rem 1.25rem 3.5rem;
-}
-
-.panel {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 16px;
-  padding: 1.5rem;
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
-}
-
-.muted {
-  color: var(--muted);
-}
-
-.accent {
-  color: var(--accent);
-}
-
-.grid {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+label {
+  color: var(--text);
+  display: block;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,11 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
 import './globals.css';
-import './styles/brand.css';
-import { AppShell } from '@/components/layout/AppShell';
-import { Header } from '@/components/layout/Header';
-import { Footer } from '@/components/layout/Footer';
+import { SiteLayout } from '@/components/Layout/SiteLayout';
 
 export const metadata: Metadata = {
-  title: 'BlackRoad OS — Web',
-  description: 'Browser-native interface for BlackRoad OS.'
+  title: 'BlackRoad OS',
+  description: 'BlackRoad OS is an AI-first operating system that lets one human orchestrator run 10,000+ virtual employees safely in regulated environments.'
 };
 
 export default function RootLayout({
@@ -19,11 +16,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <AppShell>
-          <Header />
-          <main>{children}</main>
-          <Footer />
-        </AppShell>
+        <SiteLayout>{children}</SiteLayout>
       </body>
     </html>
   );

--- a/app/legal/privacy/page.tsx
+++ b/app/legal/privacy/page.tsx
@@ -1,0 +1,52 @@
+import type { Metadata } from 'next';
+import styles from '../../marketing.module.css';
+
+export const metadata: Metadata = {
+  title: 'Privacy | BlackRoad OS',
+  description: 'Placeholder privacy notice for BlackRoad OS marketing site.'
+};
+
+export default function PrivacyPage() {
+  return (
+    <div>
+      <section className={`section ${styles.pageHeader}`}>
+        <div className="section-inner">
+          <div className={styles.tagRow}>
+            <span className={styles.pill}>Legal</span>
+            <span className={styles.pill}>Privacy</span>
+          </div>
+          <h1 className="section-title">Privacy Notice</h1>
+          <p className={styles.lead}>
+            This is placeholder content for the BlackRoad OS marketing site. Replace with counsel-reviewed language before production use.
+          </p>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="section-inner card">
+          <h3>Introduction & scope</h3>
+          <p className="muted">This notice covers the marketing site experience only and does not govern customer contracts.</p>
+
+          <h3>Information collected</h3>
+          <p className="muted">Contact details submitted via forms or email requests.</p>
+
+          <h3>Use of information</h3>
+          <p className="muted">To respond to inquiries, schedule demos, and share product updates.</p>
+
+          <h3>Cookies / analytics</h3>
+          <p className="muted">Placeholder – configure your analytics and cookie banner according to your policies.</p>
+
+          <h3>Data retention</h3>
+          <p className="muted">Retained as long as needed to respond to requests or as required by law.</p>
+
+          <h3>Contact</h3>
+          <p className="muted">Reach out via <a href="mailto:hello@blackroad.systems">hello@blackroad.systems</a> for privacy questions.</p>
+
+          <p className="muted" style={{ marginTop: '1rem' }}>
+            TODO: Replace placeholder text with counsel-approved policy and regional disclosures.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/legal/terms/page.tsx
+++ b/app/legal/terms/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from 'next';
+import styles from '../../marketing.module.css';
+
+export const metadata: Metadata = {
+  title: 'Terms | BlackRoad OS',
+  description: 'Placeholder terms of use for the BlackRoad OS marketing site.'
+};
+
+export default function TermsPage() {
+  return (
+    <div>
+      <section className={`section ${styles.pageHeader}`}>
+        <div className="section-inner">
+          <div className={styles.tagRow}>
+            <span className={styles.pill}>Legal</span>
+            <span className={styles.pill}>Terms</span>
+          </div>
+          <h1 className="section-title">Terms of Use</h1>
+          <p className={styles.lead}>
+            Placeholder terms for the marketing site only. Replace with definitive terms reviewed by counsel before launch.
+          </p>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="section-inner card">
+          <h3>Acceptance of terms</h3>
+          <p className="muted">By browsing this marketing site you agree to these placeholder terms.</p>
+
+          <h3>No warranty</h3>
+          <p className="muted">The site and content are provided without warranty and may change without notice.</p>
+
+          <h3>Intellectual property</h3>
+          <p className="muted">Content, marks, and brand assets belong to BlackRoad OS unless otherwise noted.</p>
+
+          <h3>Limitation of liability</h3>
+          <p className="muted">Use this site at your own risk. BlackRoad OS is not liable for damages arising from its use.</p>
+
+          <h3>Governing law</h3>
+          <p className="muted">Specify jurisdiction once finalized with counsel.</p>
+
+          <p className="muted" style={{ marginTop: '1rem' }}>
+            TODO: Replace placeholder text with full legal terms and jurisdictional details.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/marketing.module.css
+++ b/app/marketing.module.css
@@ -1,0 +1,39 @@
+.pageHeader {
+  padding: 56px 0 28px;
+}
+
+.lead {
+  color: var(--muted);
+  max-width: 820px;
+  line-height: 1.7;
+  margin-top: 0.75rem;
+}
+
+.tagRow {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 0.9rem;
+}
+
+.callout {
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 16px;
+  padding: 1.25rem;
+  background: rgba(255, 255, 255, 0.04);
+  margin: 1.25rem 0;
+  color: var(--muted);
+  line-height: 1.6;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,77 +1,138 @@
-import styles from './page.module.css';
-import { StatusWidget } from '@/components/status/StatusWidget';
+import type { Metadata } from 'next';
+import { CTASection } from '@/components/CTASection';
+import { FeatureSection } from '@/components/FeatureSection';
+import { Hero } from '@/components/Hero';
+import { LogoCloud } from '@/components/LogoCloud';
+import { SplitSection } from '@/components/SplitSection';
+import { CTA_DESTINATION } from '@/lib/routes';
 
-const consoleUrl = process.env.NEXT_PUBLIC_CONSOLE_URL || 'https://console.blackroad.systems';
-const docsUrl = process.env.NEXT_PUBLIC_DOCS_URL || 'https://docs.blackroad.systems';
+export const metadata: Metadata = {
+  title: 'BlackRoad OS — AI Operating System',
+  description:
+    'Run a 10,000-person company with one human orchestrator. BlackRoad OS coordinates AI agents with cryptographic audit trails, finance automation, and policy-driven guardrails.'
+};
 
-const pillars = [
+const heroMetrics = [
   {
-    title: 'Orchestration',
-    description: 'Coordinated workflows for agents, services, and ledger-aware actions.'
+    title: '10,000+ virtual employees',
+    description: 'Composable agents for finance, legal, operations, and product domains.'
   },
   {
-    title: 'Observability',
-    description: 'Built-in telemetry, health, and audit layers to keep operators in control.'
+    title: 'One human orchestrator',
+    description: 'Humans approve thresholds, policies, and critical actions while agents execute.'
   },
   {
-    title: 'Compliance',
-    description: 'Policy-driven safeguards that keep the platform aligned with governance.'
+    title: 'Audit-first architecture',
+    description: 'Every action is journaled with hashes, lineage, and policy context.'
+  }
+];
+
+const orchestrationFeatures = [
+  {
+    icon: '⚡️',
+    title: 'One orchestrator, many agents',
+    description: 'blackroad-os-core and blackroad-os-operator coordinate thousands of domain-specific agents with policies, queues, and service mesh awareness.'
+  },
+  {
+    icon: '🧭',
+    title: 'Policy-driven routing',
+    description: 'Safeguards ensure the right agent executes with the right context, approvals, and compliance envelopes.'
+  },
+  {
+    icon: '🛰️',
+    title: 'Event-native runtime',
+    description: 'Event bus, journaling, and replay let you simulate, approve, and monitor automated work before it touches production data.'
+  }
+];
+
+const financeFeatures = [
+  {
+    icon: '💹',
+    title: 'Automated Finance Layer',
+    description: 'CFO, Controller, FP&A, and Treasury agents collaborate on closes, cash, and capital flows—always tagged to immutable audit trails.'
+  },
+  {
+    icon: '📊',
+    title: 'Real-time reporting',
+    description: 'Programmatic reports with drill-downs, anomaly detection, and policy-aware escalations to humans.'
+  },
+  {
+    icon: '🔐',
+    title: 'Compliance-native',
+    description: 'PS-SHA∞ journaling with hash links across ledgers, advice, and actions so regulated teams stay exam-ready.'
+  }
+];
+
+const prismFeatures = [
+  {
+    icon: '🖥️',
+    title: 'Single pane of glass',
+    description: 'Prism Console shows live agents, tasks, audit logs, and controls in one secure interface.'
+  },
+  {
+    icon: '📡',
+    title: 'Health + observability',
+    description: 'Status, traces, and event trails across every automated workflow keep humans in charge.'
+  },
+  {
+    icon: '🛡️',
+    title: 'Human-in-the-loop safety',
+    description: 'High-impact actions always route through approvals and capture rationale for downstream audit.'
   }
 ];
 
 export default function HomePage() {
   return (
-    <div className={styles.page}>
-      <section className={`panel ${styles.hero}`}>
-        <p className="muted">BlackRoad Operating System</p>
-        <h1>BlackRoad OS</h1>
-        <p className={styles.subtitle}>
-          The operations layer for secure, ledger-native automation. Build, observe, and control the
-          BlackRoad stack from a single, trusted interface.
-        </p>
-        <div className={styles.ctaRow}>
-          <a className={styles.ctaButton} href={consoleUrl} target="_blank" rel="noreferrer">
-            View Console
-          </a>
-          <a className={styles.ctaButtonSecondary} href={docsUrl} target="_blank" rel="noreferrer">
-            Read Docs
-          </a>
-        </div>
-      </section>
+    <div>
+      <Hero
+        title="Run a 10,000-person company with one human orchestrator."
+        subtitle="BlackRoad OS is an AI-first operating system that coordinates thousands of specialized agents with cryptographic audit trails, policy guardrails, and finance automation built in."
+        primaryCta={{ label: 'Request Early Access', href: CTA_DESTINATION }}
+        secondaryCta={{ label: 'View Architecture', href: '/product' }}
+        metrics={heroMetrics}
+      />
 
-      <section className={`panel ${styles.section}`}>
-        <div className={styles.sectionHeader}>
-          <div>
-            <p className="muted">Platform overview</p>
-            <h2>What is BlackRoad OS?</h2>
-            <p className={styles.subtitle}>
-              A cohesive runtime that spans the core ledger, operator services, web interfaces, and
-              console workflows.
-            </p>
-          </div>
-        </div>
-        <div className={styles.cardGrid}>
-          {pillars.map((pillar) => (
-            <div key={pillar.title} className={styles.card}>
-              <h3>{pillar.title}</h3>
-              <p className="muted">{pillar.description}</p>
-            </div>
-          ))}
-        </div>
-      </section>
+      <FeatureSection
+        title="Orchestration Engine"
+        subtitle="blackroad-os-core and blackroad-os-operator form a governed fabric where agents are composable, observable, and policy-aware."
+        items={orchestrationFeatures}
+      />
 
-      <section className={`panel ${styles.section}`}>
-        <div className={styles.sectionHeader}>
-          <div>
-            <p className="muted">Live telemetry</p>
-            <h2>System Snapshot</h2>
-            <p className={styles.subtitle}>
-              Quick glance at the public-facing services powering BlackRoad OS.
-            </p>
-          </div>
-        </div>
-        <StatusWidget />
-      </section>
+      <FeatureSection
+        title="Automated Finance & Compliance"
+        subtitle="Purpose-built finance agents cover close, cash, treasury, tax, and FP&A with human gates for critical moves."
+        items={financeFeatures}
+      />
+
+      <FeatureSection
+        title="Prism Console"
+        subtitle="Your single pane of glass for monitoring, approvals, audit trails, and human overrides across every agent."
+        items={prismFeatures}
+      />
+
+      <SplitSection
+        eyebrow="Regulated by design"
+        title="Born for FINRA/SEC/AML/KYC environments"
+        description="PS-SHA∞ journaling, suitability-aware logic, and policy-based routing make the system safe for regulated enterprises from day one."
+        bullets={[
+          'Every decision and payload hashed with lineage for auditability.',
+          'Policy-driven automation with human gates for critical thresholds.',
+          'Context-aware agents for finance, legal, and governance-heavy workflows.'
+        ]}
+        visualTitle="Built-in controls"
+        visualCopy="Deterministic approvals, immutable journals, and safe rollback paths mean you can trust large-scale automation without giving up governance."
+      />
+
+      <LogoCloud />
+
+      <CTASection
+        title="Book a session with Cecilia"
+        copy="Tell us about your operating model, regulatory posture, and where you need scale. We will map your environment to the BlackRoad OS agent fabric."
+        primaryLabel="Talk to Cecilia"
+        primaryHref={CTA_DESTINATION}
+        secondaryLabel="View docs"
+        secondaryHref={process.env.NEXT_PUBLIC_DOCS_URL || 'https://docs.blackroad.systems'}
+      />
     </div>
   );
 }

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -1,0 +1,70 @@
+import type { Metadata } from 'next';
+import styles from '../marketing.module.css';
+
+const plans = [
+  {
+    name: 'Solo',
+    price: 'Starting at $X/month',
+    description: 'For individual founders and small pods.',
+    features: ['Up to 50 agents', 'Automated finance basics', 'Prism Console access', 'Email support']
+  },
+  {
+    name: 'Team',
+    price: 'Custom pricing',
+    description: 'For startups and specialist firms that need more orchestration.',
+    features: ['Expanded agent pools and domains', 'Multi-user orchestrator access', 'Priority support', 'Implementation guidance']
+  },
+  {
+    name: 'Enterprise / Regulated',
+    price: 'Let’s scope together',
+    description: 'For finance, law, Big-4, and large regulated enterprises.',
+    features: [
+      'Compliance-focused modules and controls',
+      'Custom integrations and data residency options',
+      'SLAs, governance features, and dedicated CSM',
+      'Architecture reviews with the BlackRoad team'
+    ]
+  }
+];
+
+export const metadata: Metadata = {
+  title: 'Pricing | BlackRoad OS',
+  description: 'Indicative pricing tiers for BlackRoad OS with orchestration, Prism Console, and compliance modules.'
+};
+
+export default function PricingPage() {
+  return (
+    <div>
+      <section className={`section ${styles.pageHeader}`}>
+        <div className="section-inner">
+          <div className={styles.tagRow}>
+            <span className={styles.pill}>Pricing</span>
+            <span className={styles.pill}>Early access</span>
+          </div>
+          <h1 className="section-title">Pricing is early and indicative only</h1>
+          <p className={styles.lead}>
+            Final terms depend on your regulatory posture, data boundaries, and automation scope. We tailor the deployment with your
+            risk, compliance, and finance leads.
+          </p>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="section-inner card-grid">
+          {plans.map((plan) => (
+            <div key={plan.name} className="card">
+              <h3>{plan.name}</h3>
+              <p className="muted">{plan.description}</p>
+              <p style={{ fontWeight: 700, margin: '0.75rem 0' }}>{plan.price}</p>
+              <ul className="list-disc">
+                {plan.features.map((feature) => (
+                  <li key={feature}>{feature}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/product/page.tsx
+++ b/app/product/page.tsx
@@ -1,0 +1,69 @@
+import type { Metadata } from 'next';
+import { CTASection } from '@/components/CTASection';
+import { SplitSection } from '@/components/SplitSection';
+import styles from '../marketing.module.css';
+
+export const metadata: Metadata = {
+  title: 'Product | BlackRoad OS',
+  description: 'Understand BlackRoad OS Core, Operator, and Prism Console across orchestration, automation, and observability.'
+};
+
+export default function ProductPage() {
+  return (
+    <div>
+      <header className={`section ${styles.pageHeader}`}>
+        <div className="section-inner">
+          <div className={styles.tagRow}>
+            <span className={styles.pill}>Product overview</span>
+            <span className={styles.pill}>AI-first OS</span>
+          </div>
+          <h1 className="section-title">The operating system for orchestrating 10,000+ agents</h1>
+          <p className={styles.lead}>
+            BlackRoad OS brings together a ledger-native core, policy-driven operator, and Prism Console so one human can direct
+            thousands of specialized agents with confidence.
+          </p>
+        </div>
+      </header>
+
+      <SplitSection
+        eyebrow="BlackRoad OS Core"
+        title="Ledger-native event bus + journaling"
+        description="OS Core is the substrate for agents. It provides an event bus, deterministic journaling, and composable agent models so regulated workflows stay verifiable."
+        bullets={['Immutable journal with hashes and lineage', 'Composable agents with domain-specific skills', 'Replay, simulate, and compare behaviors before promotion']}
+        visualTitle="Why it matters"
+        visualCopy="Your automation footprint inherits auditability, versioned behaviors, and consistent guardrails no matter which domain team builds the agent."
+      />
+
+      <SplitSection
+        eyebrow="Operator"
+        title="Policies, scheduling, and human gates"
+        description="blackroad-os-operator routes tasks, enforces policies, and keeps humans in the loop for critical thresholds."
+        bullets={['Role- and policy-aware orchestration', 'Scheduling and dependency management across agents', 'Finance-focused examples: close, cash, treasury, tax workflows']}
+        visualTitle="Example: Automated Finance Layer"
+        visualCopy="CFO, Controller, FP&A, and Treasury agents collaborate. Operator enforces segregation of duties, approvals, and evidences every action for auditors."
+      />
+
+      <SplitSection
+        eyebrow="Prism Console"
+        title="Single pane of glass for oversight"
+        description="Prism surfaces agent health, audit logs, approvals, and performance so one orchestrator can supervise 10,000+ virtual employees."
+        bullets={[
+          'Live dashboards for agents, queues, and events',
+          'Audit-ready logs with human rationale capture',
+          'Controls for pausing, approving, or re-routing work'
+        ]}
+        visualTitle="Operator-in-command"
+        visualCopy="One human can review, approve, and direct complex programs while the platform keeps every action compliant and observable."
+      />
+
+      <CTASection
+        title="See the OS in action"
+        copy="Walk through a guided scenario that shows how core, operator, and Prism Console combine to ship governed automation."
+        primaryLabel="Request Early Access"
+        primaryHref="/contact"
+        secondaryLabel="View docs"
+        secondaryHref={process.env.NEXT_PUBLIC_DOCS_URL || 'https://docs.blackroad.systems'}
+      />
+    </div>
+  );
+}

--- a/app/regulated/page.tsx
+++ b/app/regulated/page.tsx
@@ -1,0 +1,105 @@
+import type { Metadata } from 'next';
+import { CTASection } from '@/components/CTASection';
+import styles from '../marketing.module.css';
+
+export const metadata: Metadata = {
+  title: 'Regulated Industries | BlackRoad OS',
+  description: 'BlackRoad OS for finance, law, Big-4, and regulated enterprises with audit-first automation and human-in-the-loop controls.'
+};
+
+const caseStudies = [
+  {
+    title: 'Liquidity + close automation',
+    copy: 'A CFO configures daily liquidity sweeps, weekly closes, and covenant checks. Agents execute, Operator enforces approvals, and Prism shows journals for every step.'
+  },
+  {
+    title: 'Advice oversight',
+    copy: 'A CCO reviews Prism Console audit logs to validate that recommendations captured suitability data, applied policy rules, and routed human approvals at required thresholds.'
+  }
+];
+
+export default function RegulatedPage() {
+  return (
+    <div>
+      <section className={`section ${styles.pageHeader}`}>
+        <div className="section-inner">
+          <div className={styles.tagRow}>
+            <span className={styles.pill}>Regulated buyers</span>
+            <span className={styles.pill}>Audit-first</span>
+          </div>
+          <h1 className="section-title">Built for FINRA/SEC/AML/KYC environments</h1>
+          <p className={styles.lead}>
+            Agents understand compliance workflows, capture suitability context, and journal every action. BlackRoad OS keeps humans in
+            command for capital raises, legal commitments, and regulatory filings.
+          </p>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="section-inner card-grid">
+          <div className="card">
+            <h3>Audit-ready by default</h3>
+            <p className="muted">
+              Every decision, payload, and recommendation is hashed, linked, and replayable. Internal and external auditors can trace
+              lineage without engineering lift.
+            </p>
+            <ul className="list-disc">
+              <li>Immutable PS-SHA∞ journaling</li>
+              <li>Hash-linked evidence across data sources</li>
+              <li>Human rationale capture for approvals</li>
+            </ul>
+          </div>
+
+          <div className="card">
+            <h3>Safe human-gate design</h3>
+            <p className="muted">
+              Critical thresholds always require human signoff. Agents elevate edge cases, policy exceptions, and high-risk moves to the
+              orchestrator.
+            </p>
+            <ul className="list-disc">
+              <li>Deterministic approval chains</li>
+              <li>Capital, legal, and regulatory moves gated to humans</li>
+              <li>Live controls to pause, re-route, or roll back</li>
+            </ul>
+          </div>
+
+          <div className="card">
+            <h3>Regulation-aware agents</h3>
+            <p className="muted">
+              Agents operate with FINRA/SEC/AML/KYC context in mind—suitability checks, order handling cues, and policy-driven automation that respects jurisdictions.
+            </p>
+            <ul className="list-disc">
+              <li>Suitability and order-handling logic</li>
+              <li>AML/KYC checks routed to trusted services</li>
+              <li>Policy libraries aligned with your governance</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="section-inner">
+          <h2 className="section-title">Case-style examples</h2>
+          <p className="section-subtitle">Narratives that illustrate how regulated operators stay in command.</p>
+          <div className="card-grid">
+            {caseStudies.map((story) => (
+              <div key={story.title} className="card">
+                <h3>{story.title}</h3>
+                <p className="muted">{story.copy}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <CTASection
+        title="Talk to us about your regulatory environment"
+        copy="Share your supervisory structure, data boundaries, and control requirements. We will tailor the orchestration model to your compliance posture."
+        primaryLabel="Request Early Access"
+        primaryHref="/contact"
+        secondaryLabel="View docs"
+        secondaryHref={process.env.NEXT_PUBLIC_DOCS_URL || 'https://docs.blackroad.systems'}
+      />
+    </div>
+  );
+}

--- a/docs/site-structure.md
+++ b/docs/site-structure.md
@@ -1,0 +1,22 @@
+# Site structure
+
+## Pages
+- `/` — homepage with hero, orchestration/finance/compliance messaging, logo cloud, and CTA.
+- `/product` — overview of OS Core, Operator, and Prism Console.
+- `/pricing` — indicative Solo/Team/Enterprise tiers.
+- `/regulated` — messaging for finance, legal, Big-4, and other regulated buyers.
+- `/about` — story and philosophy.
+- `/contact` — early access/contact form (static placeholder).
+- `/legal/privacy` and `/legal/terms` — placeholder legal stubs.
+- Legacy routes remain under `/app` for console/status demos.
+
+## Components
+- `src/components/Layout/*` — shared SiteLayout, NavBar, Footer.
+- `src/components/Hero.tsx` — hero block for homepage.
+- `src/components/FeatureSection.tsx` — reusable feature grid.
+- `src/components/SplitSection.tsx` — text/visual split layout.
+- `src/components/LogoCloud.tsx` — industry target placeholders.
+- `src/components/CTASection.tsx` — bold call-to-action block.
+
+## Navigation
+Navigation links are defined in `src/lib/routes.ts` and consumed by `NavBar`. Update that file when adding or renaming pages.

--- a/src/components/CTASection.module.css
+++ b/src/components/CTASection.module.css
@@ -1,0 +1,35 @@
+.section {
+  padding: 72px 0;
+}
+
+.inner {
+  width: min(1100px, 92vw);
+  margin: 0 auto;
+  border-radius: 18px;
+  padding: 2rem;
+  background:
+    linear-gradient(135deg, rgba(255, 0, 102, 0.18), rgba(0, 102, 255, 0.18)),
+    rgba(8, 6, 14, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.35);
+  text-align: center;
+}
+
+.title {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+}
+
+.copy {
+  margin: 0 auto 1.5rem;
+  max-width: 720px;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.actions {
+  display: flex;
+  justify-content: center;
+  gap: 0.85rem;
+  flex-wrap: wrap;
+}

--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -1,0 +1,31 @@
+import styles from './CTASection.module.css';
+
+interface CTASectionProps {
+  title: string;
+  copy: string;
+  primaryLabel: string;
+  primaryHref: string;
+  secondaryLabel?: string;
+  secondaryHref?: string;
+}
+
+export function CTASection({ title, copy, primaryLabel, primaryHref, secondaryLabel, secondaryHref }: CTASectionProps) {
+  return (
+    <section className={styles.section}>
+      <div className={styles.inner}>
+        <h3 className={styles.title}>{title}</h3>
+        <p className={styles.copy}>{copy}</p>
+        <div className={styles.actions}>
+          <a className="cta-button" href={primaryHref}>
+            {primaryLabel}
+          </a>
+          {secondaryHref && secondaryLabel ? (
+            <a className="cta-button secondary" href={secondaryHref}>
+              {secondaryLabel}
+            </a>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import type { FormEvent } from 'react';
+
+export function ContactForm() {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    // TODO: Replace with backend submission
+    // eslint-disable-next-line no-console
+    console.log('Contact form submission', Object.fromEntries(formData.entries()));
+    alert('Thanks! We will reach out shortly.');
+  };
+
+  return (
+    <form className="card" onSubmit={handleSubmit}>
+      <div className="grid">
+        <label>
+          <div>Name</div>
+          <input name="name" required className="panel" style={{ width: '100%', marginTop: '0.35rem' }} />
+        </label>
+        <label>
+          <div>Company</div>
+          <input name="company" required className="panel" style={{ width: '100%', marginTop: '0.35rem' }} />
+        </label>
+      </div>
+
+      <div className="grid">
+        <label>
+          <div>Email</div>
+          <input type="email" name="email" required className="panel" style={{ width: '100%', marginTop: '0.35rem' }} />
+        </label>
+        <label>
+          <div>Industry</div>
+          <input name="industry" className="panel" style={{ width: '100%', marginTop: '0.35rem' }} />
+        </label>
+      </div>
+
+      <label>
+        <div>Message</div>
+        <textarea name="message" rows={4} className="panel" style={{ width: '100%', marginTop: '0.35rem' }} />
+      </label>
+
+      <p className="muted" style={{ marginTop: '0.75rem' }}>
+        This form is static. Submissions will be wired to a backend in a future iteration.
+      </p>
+
+      <button type="submit" className="cta-button" style={{ marginTop: '1rem' }}>
+        Request Early Access
+      </button>
+    </form>
+  );
+}

--- a/src/components/FeatureSection.module.css
+++ b/src/components/FeatureSection.module.css
@@ -1,0 +1,42 @@
+.section {
+  padding: 64px 0;
+}
+
+.header {
+  margin-bottom: 1.5rem;
+}
+
+.items {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.25rem;
+}
+
+.item {
+  padding: 1.4rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.icon {
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  margin-bottom: 0.85rem;
+}
+
+.itemTitle {
+  margin: 0 0 0.35rem;
+}
+
+.itemDescription {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}

--- a/src/components/FeatureSection.tsx
+++ b/src/components/FeatureSection.tsx
@@ -1,0 +1,35 @@
+import styles from './FeatureSection.module.css';
+
+type FeatureItem = {
+  icon: string;
+  title: string;
+  description: string;
+};
+
+interface FeatureSectionProps {
+  title: string;
+  subtitle?: string;
+  items: FeatureItem[];
+}
+
+export function FeatureSection({ title, subtitle, items }: FeatureSectionProps) {
+  return (
+    <section className={styles.section}>
+      <div className="section-inner">
+        <div className={styles.header}>
+          <h2 className="section-title">{title}</h2>
+          {subtitle ? <p className="section-subtitle">{subtitle}</p> : null}
+        </div>
+        <div className={styles.items}>
+          {items.map((item) => (
+            <div key={item.title} className={styles.item}>
+              <div className={styles.icon}>{item.icon}</div>
+              <h3 className={styles.itemTitle}>{item.title}</h3>
+              <p className={styles.itemDescription}>{item.description}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Hero.module.css
+++ b/src/components/Hero.module.css
@@ -1,0 +1,116 @@
+.hero {
+  padding: 96px 0 64px;
+  position: relative;
+  overflow: hidden;
+}
+
+.heroInner {
+  width: min(1200px, 92vw);
+  margin: 0 auto;
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: center;
+}
+
+.ribbon {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  width: fit-content;
+  font-weight: 600;
+  color: #fff;
+}
+
+.title {
+  font-size: clamp(2.5rem, 6vw, 3.6rem);
+  margin: 0.35rem 0 1rem;
+  line-height: 1.1;
+}
+
+.subtitle {
+  color: var(--muted);
+  line-height: 1.7;
+  margin-bottom: 1.6rem;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  align-items: center;
+}
+
+.metrics {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+}
+
+.metricCard {
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: #fff;
+}
+
+.metricTitle {
+  font-weight: 700;
+  margin: 0;
+}
+
+.metricCopy {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.graphic {
+  border-radius: 18px;
+  padding: 1.4rem;
+  background:
+    linear-gradient(135deg, rgba(255, 0, 102, 0.2), rgba(0, 102, 255, 0.12)),
+    rgba(12, 10, 20, 0.65);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.3);
+}
+
+.diagramTitle {
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.diagramList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.65rem;
+  color: var(--text);
+}
+
+.diagramItem {
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.06);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.tag {
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 0.85rem;
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,74 @@
+import styles from './Hero.module.css';
+
+interface Metric {
+  title: string;
+  description: string;
+}
+
+interface HeroProps {
+  title: string;
+  subtitle: string;
+  primaryCta: { label: string; href: string };
+  secondaryCta: { label: string; href: string };
+  metrics: Metric[];
+}
+
+export function Hero({ title, subtitle, primaryCta, secondaryCta, metrics }: HeroProps) {
+  return (
+    <section className={styles.hero}>
+      <div className={styles.heroInner}>
+        <div>
+          <div className={styles.ribbon}>
+            AI-first operating system • 10,000+ virtual employees • One orchestrator
+          </div>
+          <h1 className={styles.title}>{title}</h1>
+          <p className={styles.subtitle}>{subtitle}</p>
+          <div className={styles.actions}>
+            <a className="cta-button" href={primaryCta.href}>
+              {primaryCta.label}
+            </a>
+            <a className="cta-button secondary" href={secondaryCta.href}>
+              {secondaryCta.label}
+            </a>
+          </div>
+          <div className={styles.metrics}>
+            {metrics.map((metric) => (
+              <div key={metric.title} className={styles.metricCard}>
+                <div>
+                  <p className={styles.metricTitle}>{metric.title}</p>
+                  <p className={styles.metricCopy}>{metric.description}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className={styles.graphic} aria-label="BlackRoad OS architecture overview">
+          <div className={styles.diagramTitle}>Operational architecture</div>
+          <ul className={styles.diagramList}>
+            <li className={styles.diagramItem}>
+              <span>OS Core</span>
+              <span className={styles.tag}>Ledger + event bus</span>
+            </li>
+            <li className={styles.diagramItem}>
+              <span>Operator</span>
+              <span className={styles.tag}>Policies + orchestration</span>
+            </li>
+            <li className={styles.diagramItem}>
+              <span>Prism Console</span>
+              <span className={styles.tag}>Audit-ready console</span>
+            </li>
+            <li className={styles.diagramItem}>
+              <span>Automated Finance</span>
+              <span className={styles.tag}>CFO stack in agents</span>
+            </li>
+            <li className={styles.diagramItem}>
+              <span>Human gate</span>
+              <span className={styles.tag}>One orchestrator</span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Layout/Footer.module.css
+++ b/src/components/Layout/Footer.module.css
@@ -1,0 +1,56 @@
+.footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(5, 1, 15, 0.82);
+  margin-top: 2rem;
+}
+
+.footerInner {
+  width: min(1200px, 92vw);
+  margin: 0 auto;
+  padding: 1.75rem 0 2rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.85rem 1.5rem;
+  justify-content: space-between;
+  color: var(--br-text-secondary);
+}
+
+.links {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.link {
+  color: var(--br-text-secondary);
+  padding: 0.35rem 0.55rem;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  transition: border 160ms ease, color 160ms ease;
+}
+
+.link:hover {
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.15);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 600;
+  color: #fff;
+}
+
+.brandMark {
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  background: var(--br-grad-full);
+  display: grid;
+  place-items: center;
+  color: #0a0a0f;
+  font-weight: 800;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.35);
+}

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+import { DOCS_URL, GITHUB_URL } from '@/lib/routes';
+import styles from './Footer.module.css';
+
+export function Footer() {
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer className={styles.footer}>
+      <div className={styles.footerInner}>
+        <div className={styles.brand}>
+          <span className={styles.brandMark}>BR</span>
+          <span>BlackRoad OS</span>
+        </div>
+        <div className={styles.links}>
+          <Link className={styles.link} href="/legal/privacy">
+            Privacy
+          </Link>
+          <Link className={styles.link} href="/legal/terms">
+            Terms
+          </Link>
+          <a className={styles.link} href={DOCS_URL} target="_blank" rel="noreferrer">
+            Docs
+          </a>
+          <a className={styles.link} href={GITHUB_URL} target="_blank" rel="noreferrer">
+            GitHub
+          </a>
+        </div>
+        <div className={styles.links}>
+          <span>© {currentYear} BlackRoad OS. All rights reserved.</span>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/Layout/NavBar.module.css
+++ b/src/components/Layout/NavBar.module.css
@@ -1,0 +1,133 @@
+.navbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(10px);
+  background: rgba(5, 1, 15, 0.75);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.navInner {
+  width: min(1200px, 92vw);
+  margin: 0 auto;
+  padding: 1.1rem 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: 0.01em;
+}
+
+.brandMark {
+  width: 38px;
+  height: 38px;
+  border-radius: 12px;
+  background: var(--br-grad-full);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+  display: grid;
+  place-items: center;
+  color: #0a0a0f;
+  font-weight: 800;
+}
+
+.navLinks {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex: 1;
+  justify-content: center;
+}
+
+.navLink {
+  padding: 0.55rem 0.75rem;
+  border-radius: 10px;
+  color: var(--br-text-secondary);
+  transition: color 160ms ease, background-color 160ms ease, border 160ms ease;
+  border: 1px solid transparent;
+}
+
+.navLink:hover,
+.navLink.active {
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.docsLink {
+  color: var(--text);
+  padding: 0.65rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+  transition: border 160ms ease, transform 160ms ease;
+}
+
+.docsLink:hover {
+  border-color: rgba(255, 255, 255, 0.35);
+  transform: translateY(-1px);
+}
+
+.ctaButton {
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: var(--br-grad-full);
+  color: #0a0a0f;
+  font-weight: 700;
+  box-shadow: 0 12px 26px rgba(255, 0, 102, 0.3);
+  transition: transform 180ms ease;
+}
+
+.ctaButton:hover {
+  transform: translateY(-1px);
+}
+
+.menuButton {
+  display: none;
+}
+
+@media (max-width: 960px) {
+  .navInner {
+    flex-wrap: wrap;
+  }
+
+  .navLinks {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .actions {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 640px) {
+  .navInner {
+    justify-content: space-between;
+  }
+
+  .navLinks {
+    display: none;
+  }
+
+  .actions {
+    width: auto;
+  }
+}

--- a/src/components/Layout/NavBar.tsx
+++ b/src/components/Layout/NavBar.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { CTA_DESTINATION, CTA_LABEL, DOCS_URL, NAV_LINKS } from '@/lib/routes';
+import styles from './NavBar.module.css';
+
+export function NavBar() {
+  const pathname = usePathname();
+
+  return (
+    <nav className={styles.navbar}>
+      <div className={styles.navInner}>
+        <Link href="/" className={styles.brand} aria-label="BlackRoad OS home">
+          <span className={styles.brandMark}>BR</span>
+          <span>BlackRoad OS</span>
+        </Link>
+
+        <div className={styles.navLinks}>
+          {NAV_LINKS.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={`${styles.navLink} ${pathname === link.href ? styles.active : ''}`.trim()}
+            >
+              {link.label}
+            </Link>
+          ))}
+          <a className={styles.navLink} href={DOCS_URL} target="_blank" rel="noreferrer">
+            Docs
+          </a>
+        </div>
+
+        <div className={styles.actions}>
+          <a className={styles.docsLink} href={DOCS_URL} target="_blank" rel="noreferrer">
+            Docs
+          </a>
+          <Link href={CTA_DESTINATION} className={styles.ctaButton}>
+            {CTA_LABEL}
+          </Link>
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/src/components/Layout/SiteLayout.module.css
+++ b/src/components/Layout/SiteLayout.module.css
@@ -1,0 +1,21 @@
+.shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(120% 120% at 0% 0%, rgba(255, 0, 102, 0.2), transparent 45%),
+    radial-gradient(120% 120% at 100% 0%, rgba(0, 102, 255, 0.18), transparent 35%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0));
+  backdrop-filter: blur(8px);
+}
+
+.main {
+  flex: 1;
+  width: 100%;
+  padding: 2.5rem 0 3.5rem;
+}
+
+@media (max-width: 720px) {
+  .main {
+    padding: 1.5rem 0 2.5rem;
+  }
+}

--- a/src/components/Layout/SiteLayout.tsx
+++ b/src/components/Layout/SiteLayout.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+import styles from './SiteLayout.module.css';
+import { NavBar } from './NavBar';
+import { Footer } from './Footer';
+
+interface SiteLayoutProps {
+  title?: string;
+  children: ReactNode;
+}
+
+export function SiteLayout({ children }: SiteLayoutProps) {
+  return (
+    <div className={styles.shell}>
+      <NavBar />
+      <main className={styles.main}>{children}</main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/components/LogoCloud.module.css
+++ b/src/components/LogoCloud.module.css
@@ -1,0 +1,32 @@
+.section {
+  padding: 48px 0;
+}
+
+.cloud {
+  width: min(1000px, 92vw);
+  margin: 0 auto;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 16px;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.title {
+  text-align: center;
+  margin: 0 0 1rem;
+}
+
+.logos {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.85rem;
+}
+
+.logoItem {
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  text-align: center;
+  color: var(--br-text-secondary);
+  background: rgba(0, 0, 0, 0.2);
+}

--- a/src/components/LogoCloud.tsx
+++ b/src/components/LogoCloud.tsx
@@ -1,0 +1,20 @@
+import styles from './LogoCloud.module.css';
+
+const targets = ['Big-4', 'Big Law', 'Fintech', 'Asset Managers', 'RIAs', 'Big Tech'];
+
+export function LogoCloud() {
+  return (
+    <section className={styles.section}>
+      <div className={styles.cloud}>
+        <h3 className={styles.title}>Built for teams like</h3>
+        <div className={styles.logos}>
+          {targets.map((target) => (
+            <div key={target} className={styles.logoItem}>
+              {target}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/SplitSection.module.css
+++ b/src/components/SplitSection.module.css
@@ -1,0 +1,59 @@
+.section {
+  padding: 72px 0;
+}
+
+.inner {
+  width: min(1200px, 92vw);
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.75rem;
+  align-items: center;
+}
+
+.copyBlock {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 1.5rem;
+  border-radius: 16px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.copyBlock h3 {
+  margin-top: 0;
+  margin-bottom: 0.6rem;
+}
+
+.copyBlock p {
+  margin: 0 0 0.85rem;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.bullets {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+data-highlight {
+  display: block;
+}
+
+.visual {
+  background: linear-gradient(160deg, rgba(0, 102, 255, 0.18), rgba(255, 0, 102, 0.14));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 16px;
+  padding: 1.25rem;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.3);
+}
+
+.visual h4 {
+  margin: 0 0 0.5rem;
+}
+
+.visual p {
+  margin: 0;
+  color: var(--muted);
+}

--- a/src/components/SplitSection.tsx
+++ b/src/components/SplitSection.tsx
@@ -1,0 +1,35 @@
+import styles from './SplitSection.module.css';
+
+interface SplitSectionProps {
+  eyebrow?: string;
+  title: string;
+  description: string;
+  bullets?: string[];
+  visualTitle: string;
+  visualCopy: string;
+}
+
+export function SplitSection({ eyebrow, title, description, bullets, visualTitle, visualCopy }: SplitSectionProps) {
+  return (
+    <section className={styles.section}>
+      <div className={styles.inner}>
+        <div className={styles.copyBlock}>
+          {eyebrow ? <p className="badge">{eyebrow}</p> : null}
+          <h3 className="section-title">{title}</h3>
+          <p className="section-subtitle">{description}</p>
+          {bullets ? (
+            <ul className={styles.bullets}>
+              {bullets.map((bullet) => (
+                <li key={bullet}>{bullet}</li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+        <div className={styles.visual}>
+          <h4>{visualTitle}</h4>
+          <p>{visualCopy}</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,0 +1,13 @@
+export const NAV_LINKS = [
+  { href: '/', label: 'Home' },
+  { href: '/product', label: 'Product' },
+  { href: '/pricing', label: 'Pricing' },
+  { href: '/regulated', label: 'Regulated' },
+  { href: '/about', label: 'About' },
+  { href: '/contact', label: 'Contact' }
+];
+
+export const DOCS_URL = process.env.NEXT_PUBLIC_DOCS_URL || 'https://docs.blackroad.systems';
+export const GITHUB_URL = 'https://github.com/blackroadlabs/blackroad-os-web';
+export const CTA_LABEL = 'Request Early Access';
+export const CTA_DESTINATION = '/contact';


### PR DESCRIPTION
## Summary
- replace the layout with a marketing-focused shell plus reusable hero/feature CTA components
- build dedicated product, pricing, regulated, about, contact, and legal pages with compliance-first messaging
- refresh docs with updated README and site structure guidance

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923726ef72083299c0ccf78397a929f)