### PR TITLE
Refresh landing page with desktop shell experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,54 @@
 # BlackRoad OS – Web
 
-Public-facing marketing site for BlackRoad OS, the AI-first operating system that lets one human orchestrator direct 10,000+ virtual employees across regulated domains.
-
-## What this repo is
-- Marketing and storytelling surface for BlackRoad OS (not the Prism admin console or API).
-- Built with Next.js 14 (App Router) and React 18 using TypeScript.
-- Includes pages for product, pricing, regulated industries, about, contact, and legal stubs.
+`blackroad-os-web` is the public-facing web experience for BlackRoad OS, styled as a retro desktop shell. It tells the story of the stack (Core, Operator, API, Prism, Web, Infra, Docs, Agents) and funnels visitors to Prism Console, Docs, or Contact.
 
 ## Getting started
-1. Install dependencies and run the dev server:
-   ```bash
-   npm install
-   npm run dev
-   ```
-   Visit [http://localhost:3000](http://localhost:3000).
 
-2. Build and start in production mode:
-   ```bash
-   npm run build
-   npm run start
-   ```
-   Default port is **8080** (configurable via `PORT`). The server binds to `0.0.0.0`.
+Install dependencies and start the dev server:
 
-## Configuration
-Key environment variables (see `.env.example`):
-- `NEXT_PUBLIC_DOCS_URL` — destination for “Docs” links.
-- `NEXT_PUBLIC_CONSOLE_URL` — console link used on legacy routes.
-- `NEXT_PUBLIC_CORE_API_URL` and `NEXT_PUBLIC_PUBLIC_API_URL` — surfaced in telemetry widgets.
-- `SERVICE_BASE_URL`, `OS_ROOT`, and other `PUBLIC_*` keys — used by runtime config and health endpoints.
+```bash
+npm install
+npm run dev
+```
 
-## Deployment (Railway)
-- Build: `npm ci && npm run build`
-- Start: `npm run start` (respects `$PORT`, defaults to 8080)
-- Health: `/health` or `/api/health`
+Build and run in production mode:
 
-## Repository structure
-- `/app` — Next.js routes (marketing pages, legacy console/status routes, API handlers)
-- `/src/components` — shared UI (layout, marketing blocks, status widgets)
-- `/src/lib` — helpers such as navigation routes
-- `/docs/site-structure.md` — notes on pages and navigation
+```bash
+npm run build
+npm run start
+```
 
-## Future enhancements
-- Add richer SEO/OpenGraph metadata per page.
-- Wire the contact form to a backend and add analytics.
-- Expand localization and accessibility coverage.
+The server binds to `0.0.0.0` and defaults to port `8080` (override with `PORT`).
+
+## Environment variables
+
+Set these to wire the navigation and calls-to-action to the right destinations:
+
+- `NEXT_PUBLIC_PRISM_URL` — URL for Prism Console.
+- `NEXT_PUBLIC_DOCS_URL` — URL for the BlackRoad docs site.
+- `NEXT_PUBLIC_CONTACT_URL` — contact or waitlist destination (falls back to `mailto:blackroad.systems@gmail.com`).
+
+## What lives here
+
+- Next.js 14 (App Router) + React 18 + TypeScript marketing shell.
+- Desktop-inspired hero + stack map describing Core, Operator, API, Prism, Web, Infra, Docs, and Agents.
+- Reusable UI primitives (`Window`, `Card`, `Button`, `Tag`) and sections for hero, stack overview, use cases, roadmap, and CTA.
+
+## Relationship to other repos
+
+This site is the public entry point for the shared **“BlackRoad OS - Master Orchestration”** project. It mirrors the same component map used across:
+
+- `blackroad-os-core` (identity, truth, events)
+- `blackroad-os-operator` (automation runtime)
+- `blackroad-os-api` (typed HTTP surface)
+- `blackroad-os-prism-console` (operator console)
+- `blackroad-os-infra` (deployments, runbooks)
+- `blackroad-os-docs` (owner’s manual)
+- Agents such as Atlas and Lucidia
+
+## Deployment notes
+
+- Health checks: `/health` or `/api/health`
+- Production build command: `npm ci && npm run build`
+- Start command: `npm run start`
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -17,7 +17,7 @@ body {
     radial-gradient(80% 80% at 50% 10%, rgba(255, 157, 0, 0.12), transparent 35%),
     var(--bg);
   color: var(--text);
-  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  font-family: var(--br-font-sans);
   -webkit-font-smoothing: antialiased;
 }
 
@@ -32,28 +32,6 @@ main {
 
 button {
   font-family: inherit;
-}
-
-.panel {
-  background: var(--panel);
-  border: 1px solid var(--border);
-  border-radius: 20px;
-  padding: 1.5rem;
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
-}
-
-.muted {
-  color: var(--muted);
-}
-
-.accent {
-  color: var(--accent);
-}
-
-.grid {
-  display: grid;
-  gap: 1.25rem;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .section {
@@ -77,46 +55,8 @@ button {
   z-index: 1;
 }
 
-.section-title {
-  font-size: clamp(2rem, 4vw, 3rem);
-  margin-bottom: 0.5rem;
-}
-
-.section-subtitle {
+.muted {
   color: var(--muted);
-  max-width: 720px;
-  line-height: 1.6;
-}
-
-.cta-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0.85rem 1.35rem;
-  border-radius: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: var(--br-grad-full);
-  color: #0a0a0f;
-  font-weight: 700;
-  transition: transform 180ms ease, box-shadow 200ms ease, opacity 180ms ease;
-  box-shadow: 0 16px 40px rgba(255, 0, 102, 0.28);
-}
-
-.cta-button:hover {
-  transform: translateY(-2px) scale(1.01);
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.45);
-}
-
-.cta-button.secondary {
-  background: transparent;
-  color: var(--text);
-  border-color: rgba(255, 255, 255, 0.12);
-  box-shadow: none;
-}
-
-.cta-button.secondary:hover {
-  border-color: rgba(255, 255, 255, 0.35);
 }
 
 .badge {
@@ -129,38 +69,6 @@ button {
   background: rgba(255, 255, 255, 0.05);
   color: var(--text);
   font-size: 0.85rem;
-}
-
-.card-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 1.5rem;
-}
-
-.card {
-  padding: 1.5rem;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 16px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
-}
-
-.card h3 {
-  margin-top: 0;
-  margin-bottom: 0.5rem;
-}
-
-.card p {
-  margin: 0;
-  color: var(--muted);
-  line-height: 1.6;
-}
-
-.list-disc {
-  list-style: disc;
-  margin: 0.75rem 0 0 1.5rem;
-  color: var(--muted);
-  line-height: 1.6;
 }
 
 body.br-login-body {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,23 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import type { ReactNode } from 'react';
 import './globals.css';
 import { SiteLayout } from '@/components/Layout/SiteLayout';
 
 export const metadata: Metadata = {
   title: 'BlackRoad OS',
-  description: 'BlackRoad OS is an AI-first operating system that lets one human orchestrator run 10,000+ virtual employees safely in regulated environments.'
+  description:
+    'BlackRoad OS is the desktop-style marketing shell that links Prism Console, docs, and the orchestration stack.',
+  openGraph: {
+    title: 'BlackRoad OS',
+    description:
+      'Public-facing web shell for the BlackRoad OS stack: Core, Operator, API, Prism, Web, Infra, Docs, and Agents.',
+    type: 'website'
+  },
+  metadataBase: new URL('https://blackroad.systems')
+};
+
+export const viewport: Viewport = {
+  themeColor: '#020008'
 };
 
 export default function RootLayout({

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,138 +1,60 @@
 import type { Metadata } from 'next';
-import { CTASection } from '@/components/CTASection';
-import { FeatureSection } from '@/components/FeatureSection';
-import { Hero } from '@/components/Hero';
-import { LogoCloud } from '@/components/LogoCloud';
-import { SplitSection } from '@/components/SplitSection';
-import { CTA_DESTINATION } from '@/lib/routes';
+import { CallToAction } from '@/components/sections/CallToAction';
+import { Hero } from '@/components/sections/Hero';
+import { SeasonsRoadmap } from '@/components/sections/SeasonsRoadmap';
+import { StackOverview } from '@/components/sections/StackOverview';
+import { UseCases } from '@/components/sections/UseCases';
+import { CONTACT_URL, DOCS_URL, PRISM_URL } from '@/lib/routes';
 
 export const metadata: Metadata = {
-  title: 'BlackRoad OS — AI Operating System',
+  title: 'BlackRoad OS — Desktop shell for orchestration',
   description:
-    'Run a 10,000-person company with one human orchestrator. BlackRoad OS coordinates AI agents with cryptographic audit trails, finance automation, and policy-driven guardrails.'
+    'BlackRoad OS is the public-facing desktop shell for orchestrating agents, infra, finance, and audit with the Prism Console and RoadChain.',
+  openGraph: {
+    title: 'BlackRoad OS — Desktop shell for orchestration',
+    description:
+      'Operate agents, infra, and finance through the BlackRoad desktop. Prism Console, RoadChain audit, and Atlas safeguards built in.',
+    siteName: 'BlackRoad OS',
+    url: 'https://blackroad.systems'
+  }
 };
 
-const heroMetrics = [
-  {
-    title: '10,000+ virtual employees',
-    description: 'Composable agents for finance, legal, operations, and product domains.'
-  },
-  {
-    title: 'One human orchestrator',
-    description: 'Humans approve thresholds, policies, and critical actions while agents execute.'
-  },
-  {
-    title: 'Audit-first architecture',
-    description: 'Every action is journaled with hashes, lineage, and policy context.'
-  }
-];
-
-const orchestrationFeatures = [
-  {
-    icon: '⚡️',
-    title: 'One orchestrator, many agents',
-    description: 'blackroad-os-core and blackroad-os-operator coordinate thousands of domain-specific agents with policies, queues, and service mesh awareness.'
-  },
-  {
-    icon: '🧭',
-    title: 'Policy-driven routing',
-    description: 'Safeguards ensure the right agent executes with the right context, approvals, and compliance envelopes.'
-  },
-  {
-    icon: '🛰️',
-    title: 'Event-native runtime',
-    description: 'Event bus, journaling, and replay let you simulate, approve, and monitor automated work before it touches production data.'
-  }
-];
-
-const financeFeatures = [
-  {
-    icon: '💹',
-    title: 'Automated Finance Layer',
-    description: 'CFO, Controller, FP&A, and Treasury agents collaborate on closes, cash, and capital flows—always tagged to immutable audit trails.'
-  },
-  {
-    icon: '📊',
-    title: 'Real-time reporting',
-    description: 'Programmatic reports with drill-downs, anomaly detection, and policy-aware escalations to humans.'
-  },
-  {
-    icon: '🔐',
-    title: 'Compliance-native',
-    description: 'PS-SHA∞ journaling with hash links across ledgers, advice, and actions so regulated teams stay exam-ready.'
-  }
-];
-
-const prismFeatures = [
-  {
-    icon: '🖥️',
-    title: 'Single pane of glass',
-    description: 'Prism Console shows live agents, tasks, audit logs, and controls in one secure interface.'
-  },
-  {
-    icon: '📡',
-    title: 'Health + observability',
-    description: 'Status, traces, and event trails across every automated workflow keep humans in charge.'
-  },
-  {
-    icon: '🛡️',
-    title: 'Human-in-the-loop safety',
-    description: 'High-impact actions always route through approvals and capture rationale for downstream audit.'
-  }
-];
-
 export default function HomePage() {
+  const prismUrl = PRISM_URL;
+  const docsUrl = DOCS_URL;
+  const contactUrl = CONTACT_URL;
+
   return (
     <div>
-      <Hero
-        title="Run a 10,000-person company with one human orchestrator."
-        subtitle="BlackRoad OS is an AI-first operating system that coordinates thousands of specialized agents with cryptographic audit trails, policy guardrails, and finance automation built in."
-        primaryCta={{ label: 'Request Early Access', href: CTA_DESTINATION }}
-        secondaryCta={{ label: 'View Architecture', href: '/product' }}
-        metrics={heroMetrics}
-      />
+      <div className="section">
+        <div className="section-inner">
+          <Hero prismUrl={prismUrl} docsUrl={docsUrl} contactUrl={contactUrl} />
+        </div>
+      </div>
 
-      <FeatureSection
-        title="Orchestration Engine"
-        subtitle="blackroad-os-core and blackroad-os-operator form a governed fabric where agents are composable, observable, and policy-aware."
-        items={orchestrationFeatures}
-      />
+      <div className="section">
+        <div className="section-inner">
+          <StackOverview docsUrl={docsUrl} />
+        </div>
+      </div>
 
-      <FeatureSection
-        title="Automated Finance & Compliance"
-        subtitle="Purpose-built finance agents cover close, cash, treasury, tax, and FP&A with human gates for critical moves."
-        items={financeFeatures}
-      />
+      <div className="section">
+        <div className="section-inner">
+          <UseCases />
+        </div>
+      </div>
 
-      <FeatureSection
-        title="Prism Console"
-        subtitle="Your single pane of glass for monitoring, approvals, audit trails, and human overrides across every agent."
-        items={prismFeatures}
-      />
+      <div className="section">
+        <div className="section-inner">
+          <SeasonsRoadmap />
+        </div>
+      </div>
 
-      <SplitSection
-        eyebrow="Regulated by design"
-        title="Born for FINRA/SEC/AML/KYC environments"
-        description="PS-SHA∞ journaling, suitability-aware logic, and policy-based routing make the system safe for regulated enterprises from day one."
-        bullets={[
-          'Every decision and payload hashed with lineage for auditability.',
-          'Policy-driven automation with human gates for critical thresholds.',
-          'Context-aware agents for finance, legal, and governance-heavy workflows.'
-        ]}
-        visualTitle="Built-in controls"
-        visualCopy="Deterministic approvals, immutable journals, and safe rollback paths mean you can trust large-scale automation without giving up governance."
-      />
-
-      <LogoCloud />
-
-      <CTASection
-        title="Book a session with Cecilia"
-        copy="Tell us about your operating model, regulatory posture, and where you need scale. We will map your environment to the BlackRoad OS agent fabric."
-        primaryLabel="Talk to Cecilia"
-        primaryHref={CTA_DESTINATION}
-        secondaryLabel="View docs"
-        secondaryHref={process.env.NEXT_PUBLIC_DOCS_URL || 'https://docs.blackroad.systems'}
-      />
+      <div className="section">
+        <div className="section-inner">
+          <CallToAction docsUrl={docsUrl} contactUrl={contactUrl} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/styles/brand-kit.css
+++ b/app/styles/brand-kit.css
@@ -9,6 +9,7 @@
   --br-deep-magenta: #d600aa;
   --br-purple: #7700ff;
   --br-cyber-blue: #0066ff;
+  --br-aqua: #5cf0d3;
 
   /* Gradients */
   --br-grad-full: linear-gradient(
@@ -21,13 +22,6 @@
     var(--br-purple) 80%,
     var(--br-cyber-blue) 100%
   );
-  --br-grad-br: linear-gradient(
-    180deg,
-    var(--br-sunrise) 0%,
-    var(--br-warm) 25%,
-    var(--br-hot-pink) 75%,
-    var(--br-magenta) 100%
-  );
   --br-grad-os: linear-gradient(
     180deg,
     var(--br-magenta) 0%,
@@ -35,6 +29,7 @@
     var(--br-purple) 75%,
     var(--br-cyber-blue) 100%
   );
+  --br-grad-soft: linear-gradient(120deg, rgba(255, 0, 102, 0.24), rgba(0, 102, 255, 0.16));
   --br-gradient-start: var(--br-sunrise);
   --br-gradient-mid: var(--br-warm);
   --br-gradient-hot: var(--br-hot-pink);
@@ -46,9 +41,12 @@
   /* Surfaces */
   --br-bg: #020008;
   --br-bg-alt: #05010f;
+  --br-bg-elevated: #0c0c18;
   --br-shell: rgba(4, 4, 10, 0.96);
   --br-surface: #0b0b12;
   --br-surface-alt: #13131f;
+  --br-border-subtle: rgba(255, 255, 255, 0.12);
+  --br-border-strong: rgba(255, 255, 255, 0.2);
 
   /* Typography */
   --br-text: #ffffff;
@@ -61,16 +59,19 @@
   --br-radius-xxl: 32px;
 
   /* Fonts */
-  --br-font-sans: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', system-ui, sans-serif;
+  --br-font-sans: 'Inter', system-ui, -apple-system, sans-serif;
   --br-font-mono: 'JetBrains Mono', 'SF Mono', ui-monospace, Menlo, monospace;
 
   /* Global aliases */
   --bg: var(--br-bg);
+  --bg-elevated: var(--br-bg-elevated);
   --panel: var(--br-surface);
-  --accent: #72e4a2;
+  --accent: var(--br-aqua);
+  --accent-strong: var(--br-hot-pink);
+  --accent-soft: rgba(255, 0, 102, 0.35);
   --muted: var(--br-text-subtle);
   --text: var(--br-text);
-  --border: rgba(255, 255, 255, 0.12);
+  --border: var(--br-border-subtle);
 
   /* Brand tokens */
   --br-gradient-primary: var(--br-grad-full);

--- a/src/components/Layout/NavBar.tsx
+++ b/src/components/Layout/NavBar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { CTA_DESTINATION, CTA_LABEL, DOCS_URL, NAV_LINKS } from '@/lib/routes';
+import { CONTACT_URL, DOCS_URL, NAV_LINKS, PRISM_URL } from '@/lib/routes';
 import styles from './NavBar.module.css';
 
 export function NavBar() {
@@ -17,27 +17,37 @@ export function NavBar() {
         </Link>
 
         <div className={styles.navLinks}>
-          {NAV_LINKS.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className={`${styles.navLink} ${pathname === link.href ? styles.active : ''}`.trim()}
-            >
-              {link.label}
-            </Link>
-          ))}
-          <a className={styles.navLink} href={DOCS_URL} target="_blank" rel="noreferrer">
-            Docs
-          </a>
+          {NAV_LINKS.map((link) => {
+            if (link.external) {
+              return (
+                <a key={link.href} href={link.href} className={styles.navLink} target="_blank" rel="noreferrer">
+                  {link.label}
+                </a>
+              );
+            }
+
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={`${styles.navLink} ${pathname === link.href ? styles.active : ''}`.trim()}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
         </div>
 
         <div className={styles.actions}>
           <a className={styles.docsLink} href={DOCS_URL} target="_blank" rel="noreferrer">
             Docs
           </a>
-          <Link href={CTA_DESTINATION} className={styles.ctaButton}>
-            {CTA_LABEL}
-          </Link>
+          <a className={styles.ctaButton} href={PRISM_URL} target="_blank" rel="noreferrer">
+            Prism Console
+          </a>
+          <a className={styles.docsLink} href={CONTACT_URL} target="_blank" rel="noreferrer">
+            Contact
+          </a>
         </div>
       </div>
     </nav>

--- a/src/components/Layout/SiteLayout.module.css
+++ b/src/components/Layout/SiteLayout.module.css
@@ -2,10 +2,12 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  background: radial-gradient(120% 120% at 0% 0%, rgba(255, 0, 102, 0.2), transparent 45%),
+  background:
+    radial-gradient(120% 120% at 0% 0%, rgba(255, 0, 102, 0.2), transparent 45%),
     radial-gradient(120% 120% at 100% 0%, rgba(0, 102, 255, 0.18), transparent 35%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0));
-  backdrop-filter: blur(8px);
+    linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(255, 255, 255, 0)),
+    var(--bg);
+  color: var(--text);
 }
 
 .main {

--- a/src/components/layout/DesktopShell.module.css
+++ b/src/components/layout/DesktopShell.module.css
@@ -1,0 +1,58 @@
+.shell {
+  position: relative;
+  padding: 2rem;
+  border-radius: 26px;
+  border: 1px solid var(--border);
+  background: radial-gradient(circle at 10% 10%, rgba(255, 0, 102, 0.2), transparent 35%),
+    radial-gradient(circle at 90% 0%, rgba(0, 102, 255, 0.22), transparent 40%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0));
+  box-shadow: 0 40px 70px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.backgroundGlow {
+  position: absolute;
+  inset: -20%;
+  pointer-events: none;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 0, 102, 0.3), transparent 45%),
+    radial-gradient(circle at 80% 10%, rgba(0, 102, 255, 0.28), transparent 50%),
+    radial-gradient(circle at 60% 90%, rgba(119, 0, 255, 0.18), transparent 40%);
+  filter: blur(40px);
+  opacity: 0.6;
+}
+
+.widgetTitle {
+  font-size: 0.95rem;
+  color: var(--muted);
+  margin: 0 0 0.35rem;
+}
+
+.widgetValue {
+  font-family: var(--br-font-mono);
+  color: #fff;
+  font-size: 1.05rem;
+}
+
+.inlineGrid {
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.muted {
+  color: var(--muted);
+  font-size: 0.9rem;
+}

--- a/src/components/layout/DesktopShell.tsx
+++ b/src/components/layout/DesktopShell.tsx
@@ -1,0 +1,96 @@
+import { Button } from '../ui/Button';
+import { Tag } from '../ui/Tag';
+import { Window } from '../ui/Window';
+import styles from './DesktopShell.module.css';
+
+interface DesktopShellProps {
+  prismUrl: string;
+  docsUrl: string;
+}
+
+export function DesktopShell({ prismUrl, docsUrl }: DesktopShellProps) {
+  return (
+    <div className={styles.shell}>
+      <div className={styles.backgroundGlow} />
+      <div className={styles.grid}>
+        <Window title="Prism Console" subtitle="Live agents & approvals" icon={<span aria-hidden>🖥️</span>}>
+          <div className={styles.inlineGrid}>
+            <div>
+              <p className={styles.widgetTitle}>Active agents</p>
+              <p className={styles.widgetValue}>42</p>
+            </div>
+            <div>
+              <p className={styles.widgetTitle}>Awaiting approval</p>
+              <p className={styles.widgetValue}>7 human gates</p>
+            </div>
+            <div>
+              <p className={styles.widgetTitle}>RoadChain events</p>
+              <p className={styles.widgetValue}>18,204</p>
+            </div>
+          </div>
+          <Button href={prismUrl} variant="secondary" style={{ marginTop: '0.8rem' }}>
+            Open Prism Console
+          </Button>
+        </Window>
+
+        <Window title="Core / Operator" subtitle="PS-SHA∞ truth + jobs" icon={<span aria-hidden>🛰️</span>}>
+          <div className={styles.inlineGrid}>
+            <div>
+              <p className={styles.widgetTitle}>Identities</p>
+              <p className={styles.widgetValue}>PS-SHA∞ x 12,448</p>
+            </div>
+            <div>
+              <p className={styles.widgetTitle}>Queued jobs</p>
+              <p className={styles.widgetValue}>1,024</p>
+            </div>
+            <div>
+              <p className={styles.widgetTitle}>Replay buffers</p>
+              <p className={styles.widgetValue}>Ready</p>
+            </div>
+          </div>
+          <div className={styles.row} style={{ marginTop: '0.8rem' }}>
+            <Tag>Policy-driven</Tag>
+            <Tag>Audit linked</Tag>
+          </div>
+        </Window>
+
+        <Window title="RoadChain" subtitle="Immutable audit" icon={<span aria-hidden>🔗</span>}>
+          <p className={styles.widgetTitle}>Recent commits</p>
+          <div className={styles.inlineGrid}>
+            <div>
+              <p className={styles.widgetValue}>#20294</p>
+              <p className={styles.muted}>Atlas upgraded finance guardrails</p>
+            </div>
+            <div>
+              <p className={styles.widgetValue}>#20295</p>
+              <p className={styles.muted}>Agent Lucidia issued research memo</p>
+            </div>
+          </div>
+          <p className={styles.muted} style={{ marginTop: '0.75rem' }}>
+            Every action is hashed, linked, and replayable.
+          </p>
+        </Window>
+
+        <Window title="Wallet & ROI" subtitle="Finance intelligence" icon={<span aria-hidden>💹</span>}>
+          <div className={styles.inlineGrid}>
+            <div>
+              <p className={styles.widgetTitle}>Runway</p>
+              <p className={styles.widgetValue}>18.4 months</p>
+            </div>
+            <div>
+              <p className={styles.widgetTitle}>Automation ROI</p>
+              <p className={styles.widgetValue}>+214%</p>
+            </div>
+            <div>
+              <p className={styles.widgetTitle}>Treasury</p>
+              <p className={styles.widgetValue}>$42.8M</p>
+            </div>
+          </div>
+          <Button href={docsUrl} variant="secondary" style={{ marginTop: '0.8rem' }}>
+            View finance stack
+          </Button>
+        </Window>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sections/CallToAction.module.css
+++ b/src/components/sections/CallToAction.module.css
@@ -1,0 +1,28 @@
+.section {
+  padding: 3rem 0 3.5rem;
+}
+
+.inner {
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 1.8rem;
+  background: linear-gradient(120deg, rgba(255, 0, 102, 0.2), rgba(0, 102, 255, 0.16));
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.35);
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.4rem);
+}
+
+.subtitle {
+  margin: 0.4rem 0 1.2rem;
+  color: var(--br-text);
+  max-width: 720px;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}

--- a/src/components/sections/CallToAction.tsx
+++ b/src/components/sections/CallToAction.tsx
@@ -1,0 +1,27 @@
+import { Button } from '../ui/Button';
+import styles from './CallToAction.module.css';
+
+interface CallToActionProps {
+  docsUrl: string;
+  contactUrl: string;
+}
+
+export function CallToAction({ docsUrl, contactUrl }: CallToActionProps) {
+  return (
+    <section className={styles.section}>
+      <div className={styles.inner}>
+        <h2 className={styles.title}>BlackRoad OS keeps your agents, infra, and finance in one shell.</h2>
+        <p className={styles.subtitle}>
+          Operators stay in Prism, Atlas watches your systems, and RoadChain journals every action. Talk to us or dive into the
+          Owner&apos;s Manual to plug your stack in.
+        </p>
+        <div className={styles.actions}>
+          <Button href={contactUrl}>Talk to us</Button>
+          <Button href={docsUrl} variant="secondary">
+            Read the Docs
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/Hero.module.css
+++ b/src/components/sections/Hero.module.css
@@ -1,0 +1,64 @@
+.hero {
+  display: grid;
+  gap: 2rem;
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  padding: 3rem 0;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.7rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
+  font-family: var(--br-font-mono);
+  color: var(--muted);
+}
+
+.title {
+  font-size: clamp(2.6rem, 4vw, 3.4rem);
+  margin: 0.4rem 0;
+  line-height: 1.1;
+}
+
+.subtitle {
+  color: var(--muted);
+  line-height: 1.7;
+  margin: 0 0 1.2rem;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.2rem;
+}
+
+.metrics {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  margin-top: 1.4rem;
+}
+
+.metric {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 0.9rem 1rem;
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.metricTitle {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.metricSubtitle {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,0 +1,57 @@
+import { DesktopShell } from '../layout/DesktopShell';
+import { Button } from '../ui/Button';
+import styles from './Hero.module.css';
+
+interface HeroProps {
+  prismUrl: string;
+  docsUrl: string;
+  contactUrl: string;
+}
+
+const HERO_METRICS = [
+  {
+    title: '10,000+ virtual employees',
+    subtitle: 'Compose domain agents with Core + Operator'
+  },
+  {
+    title: 'Immutable audit',
+    subtitle: 'RoadChain hashes every decision'
+  },
+  {
+    title: 'Human in the loop',
+    subtitle: 'Prism approvals + policy guardrails'
+  }
+];
+
+export function Hero({ prismUrl, docsUrl, contactUrl }: HeroProps) {
+  return (
+    <section className={styles.hero}>
+      <div>
+        <span className={styles.eyebrow}>BlackRoad OS • Orchestration desktop</span>
+        <h1 className={styles.title}>Orchestrate agents, infra, and finance from one BlackRoad desktop.</h1>
+        <p className={styles.subtitle}>
+          BlackRoad OS is a desktop-style shell for operating thousands of AI agents with PS-SHA∞ identity, RoadChain audit,
+          and policy-driven finance. Prism keeps humans in control while Atlas watches your infra.
+        </p>
+        <div className={styles.actions}>
+          <Button href={prismUrl}>Open Prism Console</Button>
+          <Button href={docsUrl} variant="secondary">
+            Read the Docs
+          </Button>
+          <Button href={contactUrl} variant="ghost">
+            Talk to us
+          </Button>
+        </div>
+        <div className={styles.metrics}>
+          {HERO_METRICS.map((metric) => (
+            <div key={metric.title} className={styles.metric}>
+              <p className={styles.metricTitle}>{metric.title}</p>
+              <p className={styles.metricSubtitle}>{metric.subtitle}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+      <DesktopShell prismUrl={prismUrl} docsUrl={docsUrl} />
+    </section>
+  );
+}

--- a/src/components/sections/SeasonsRoadmap.module.css
+++ b/src/components/sections/SeasonsRoadmap.module.css
@@ -1,0 +1,53 @@
+.section {
+  padding: 3rem 0;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 760px;
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.6rem);
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.timeline {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.step {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1rem 1.1rem;
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.07);
+}
+
+.stepTitle {
+  margin: 0;
+  font-weight: 700;
+}
+
+.stepSubtitle {
+  margin: 0.2rem 0 0.6rem;
+  color: var(--muted);
+  font-family: var(--br-font-mono);
+}
+
+.stepCopy {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}

--- a/src/components/sections/SeasonsRoadmap.tsx
+++ b/src/components/sections/SeasonsRoadmap.tsx
@@ -1,0 +1,45 @@
+import { Card } from '../ui/Card';
+import styles from './SeasonsRoadmap.module.css';
+
+const SEASONS = [
+  {
+    title: 'Season 0–1',
+    subtitle: 'Core & OS skeleton',
+    copy: 'PS-SHA∞ identity, journaling, and the first Operator pipelines to prove the orchestration loop.'
+  },
+  {
+    title: 'Season 2',
+    subtitle: 'Master Orchestration',
+    copy: 'Multi-repo cohesion across Core, Operator, API, Prism, and Web with env-aware deployments.'
+  },
+  {
+    title: 'Season 3',
+    subtitle: 'Intelligence layer',
+    copy: 'Atlas and Lucidia agents gain autonomy with policy rails, RoadChain anchors, and finance sensing.'
+  },
+  {
+    title: 'Season 4+',
+    subtitle: 'Ecosystem and worlds',
+    copy: 'RoadChain explorers, RoadWallet hooks, demo worlds, and partner integrations across the stack.'
+  }
+];
+
+export function SeasonsRoadmap() {
+  return (
+    <section className={styles.section}>
+      <div className={styles.header}>
+        <h2 className={styles.title}>Seasons keep the OS paced and governed.</h2>
+        <p className={styles.subtitle}>
+          Each BlackRoad repo participates in the same season arc so we can ship brand, infra, intelligence, and docs together.
+        </p>
+      </div>
+      <div className={styles.timeline}>
+        {SEASONS.map((season) => (
+          <Card key={season.title} title={season.title} description={season.copy}>
+            <p className={styles.stepSubtitle}>{season.subtitle}</p>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/StackOverview.module.css
+++ b/src/components/sections/StackOverview.module.css
@@ -1,0 +1,69 @@
+.section {
+  padding: 3rem 0;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  max-width: 760px;
+}
+
+.title {
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  margin: 0;
+}
+
+.subtitle {
+  color: var(--muted);
+  line-height: 1.6;
+  margin: 0;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1rem 1.1rem;
+  background: rgba(255, 255, 255, 0.03);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.07);
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  justify-content: space-between;
+}
+
+.name {
+  margin: 0;
+  font-weight: 700;
+}
+
+.layer {
+  font-family: var(--br-font-mono);
+  color: var(--muted);
+}
+
+.description {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.link {
+  color: var(--accent);
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-color: rgba(92, 240, 211, 0.4);
+}

--- a/src/components/sections/StackOverview.tsx
+++ b/src/components/sections/StackOverview.tsx
@@ -1,0 +1,55 @@
+import { STACK_COMPONENTS } from '@/lib/stackMap';
+import { Button } from '../ui/Button';
+import { Tag } from '../ui/Tag';
+import styles from './StackOverview.module.css';
+
+interface StackOverviewProps {
+  docsUrl: string;
+}
+
+const STATUS_COPY = {
+  planned: 'Planned',
+  alpha: 'Alpha',
+  beta: 'Beta',
+  prod: 'Production'
+} as const;
+
+export function StackOverview({ docsUrl }: StackOverviewProps) {
+  return (
+    <section className={styles.section}>
+      <div className={styles.header}>
+        <p className={styles.subtitle}>Stack map</p>
+        <h2 className={styles.title}>From Core primitives to the Prism desktop.</h2>
+        <p className={styles.subtitle}>
+          The OS spans Core identity and events, Operator runtime, typed APIs, and the Prism Console that keeps humans and agents
+          in sync. Docs and Infra tie the whole Master Orchestration project together.
+        </p>
+        <Button href={docsUrl} variant="secondary" style={{ width: 'fit-content', marginTop: '0.6rem' }}>
+          View the Owner&apos;s Manual
+        </Button>
+      </div>
+      <div className={styles.grid}>
+        {STACK_COMPONENTS.map((item) => (
+          <div key={item.id} className={styles.card}>
+            <div className={styles.row}>
+              <h3 className={styles.name}>{item.name}</h3>
+              <Tag>{STATUS_COPY[item.status]}</Tag>
+            </div>
+            <div className={styles.layer}>{item.layer}</div>
+            <p className={styles.description}>{item.description}</p>
+            {item.repo ? (
+              <a
+                href={`https://github.com/${item.repo}`}
+                target="_blank"
+                rel="noreferrer"
+                className={styles.link}
+              >
+                View repo ↗
+              </a>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/UseCases.module.css
+++ b/src/components/sections/UseCases.module.css
@@ -1,0 +1,39 @@
+.section {
+  padding: 3rem 0;
+}
+
+.header {
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(2rem, 3vw, 2.6rem);
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.grid {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.cardTitle {
+  margin: 0 0 0.35rem;
+  font-size: 1.1rem;
+}
+
+.cardCopy {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}

--- a/src/components/sections/UseCases.tsx
+++ b/src/components/sections/UseCases.tsx
@@ -1,0 +1,40 @@
+import { Card } from '../ui/Card';
+import styles from './UseCases.module.css';
+
+const USE_CASES = [
+  {
+    title: 'Ops & Infra',
+    copy: 'Unified approvals, observability, and rollback paths keep every agent action governed across clusters and services.'
+  },
+  {
+    title: 'Finance & ROI',
+    copy: 'Treasury, FP&A, and Controller agents execute with PS-SHA∞ journals so CFOs see ROI and compliance in one place.'
+  },
+  {
+    title: 'Agent Orchestration',
+    copy: 'Operator routes tasks to the right agent with policies, queues, and replay buffers for deterministic decisioning.'
+  },
+  {
+    title: 'Creators & Worlds',
+    copy: 'Demo worlds, RoadChain explorers, and RoadWallet hooks make it easy to showcase the OS publicly.'
+  }
+];
+
+export function UseCases() {
+  return (
+    <section className={styles.section}>
+      <div className={styles.header}>
+        <h2 className={styles.title}>Built for teams drowning in dashboards.</h2>
+        <p className={styles.subtitle}>
+          BlackRoad OS removes the cognitive overhead of juggling disconnected tools. Agents operate under policy, Prism tracks
+          the truth, and Atlas safeguards your infra and finances.
+        </p>
+      </div>
+      <div className={styles.grid}>
+        {USE_CASES.map((item) => (
+          <Card key={item.title} title={item.title} description={item.copy} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/ui/Button.module.css
+++ b/src/components/ui/Button.module.css
@@ -1,0 +1,52 @@
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.35rem;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 200ms ease, opacity 180ms ease, border 160ms ease;
+  font-family: var(--br-font-sans);
+  text-decoration: none;
+}
+
+.primary {
+  background: var(--br-gradient-primary);
+  color: #0a0a0f;
+  box-shadow: 0 18px 36px rgba(255, 0, 102, 0.25);
+}
+
+.secondary {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+}
+
+.ghost {
+  background: transparent;
+  color: var(--text);
+}
+
+.fullWidth {
+  width: 100%;
+}
+
+.button:hover {
+  transform: translateY(-2px) scale(1.01);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,74 @@
+import Link from 'next/link';
+import type {
+  AnchorHTMLAttributes,
+  ButtonHTMLAttributes,
+  ReactNode
+} from 'react';
+import styles from './Button.module.css';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost';
+
+type BaseProps = {
+  children: ReactNode;
+  variant?: ButtonVariant;
+  fullWidth?: boolean;
+  href?: string;
+  className?: string;
+};
+
+type ButtonOnlyProps = BaseProps & { href?: undefined } & ButtonHTMLAttributes<HTMLButtonElement>;
+type AnchorOnlyProps = BaseProps & { href: string } & AnchorHTMLAttributes<HTMLAnchorElement>;
+
+type ButtonProps = ButtonOnlyProps | AnchorOnlyProps;
+
+type AnchorProps = BaseProps & {
+  href: string;
+};
+
+function buildClassName(variant: ButtonVariant, fullWidth?: boolean, extra?: string) {
+  return [styles.button, styles[variant], fullWidth ? styles.fullWidth : '', extra]
+    .filter(Boolean)
+    .join(' ');
+}
+
+export function Button({ children, variant = 'primary', fullWidth, className, href, ...props }: ButtonProps) {
+  if (href) {
+    const isExternal = href.startsWith('http') || href.startsWith('mailto:');
+
+    if (isExternal) {
+      const anchorProps = props as AnchorHTMLAttributes<HTMLAnchorElement>;
+      return (
+        <a href={href} className={buildClassName(variant, fullWidth, className)} {...anchorProps}>
+          {children}
+        </a>
+      );
+    }
+
+    return (
+      <Link href={href} className={buildClassName(variant, fullWidth, className)}>
+        {children}
+      </Link>
+    );
+  }
+
+  return (
+    <button className={buildClassName(variant, fullWidth, className)} {...props}>
+      {children}
+    </button>
+  );
+}
+
+export function AnchorButton({
+  children,
+  variant = 'primary',
+  fullWidth,
+  className,
+  href,
+  ...props
+}: AnchorProps & AnchorHTMLAttributes<HTMLAnchorElement>) {
+  return (
+    <a href={href} className={buildClassName(variant, fullWidth, className)} {...props}>
+      {children}
+    </a>
+  );
+}

--- a/src/components/ui/Card.module.css
+++ b/src/components/ui/Card.module.css
@@ -1,0 +1,44 @@
+.card {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0));
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 1.4rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 12px 32px rgba(0, 0, 0, 0.25);
+  position: relative;
+  overflow: hidden;
+}
+
+.glow {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 0, 102, 0.2), transparent 40%),
+    radial-gradient(circle at 80% 0%, rgba(0, 102, 255, 0.15), transparent 45%);
+  opacity: 0.6;
+}
+
+.content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.heading {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-weight: 700;
+}
+
+.title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.description {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react';
+import styles from './Card.module.css';
+
+interface CardProps {
+  title: string;
+  icon?: ReactNode;
+  description?: string;
+  children?: ReactNode;
+}
+
+export function Card({ title, icon, description, children }: CardProps) {
+  return (
+    <div className={styles.card}>
+      <div className={styles.glow} />
+      <div className={styles.content}>
+        <div className={styles.heading}>
+          {icon}
+          <h3 className={styles.title}>{title}</h3>
+        </div>
+        {description && <p className={styles.description}>{description}</p>}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/Tag.module.css
+++ b/src/components/ui/Tag.module.css
@@ -1,0 +1,21 @@
+.tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
+  font-size: 0.85rem;
+  color: var(--text);
+  font-family: var(--br-font-mono);
+  letter-spacing: 0.01em;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px rgba(92, 240, 211, 0.12);
+}

--- a/src/components/ui/Tag.tsx
+++ b/src/components/ui/Tag.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react';
+import styles from './Tag.module.css';
+
+interface TagProps {
+  children: ReactNode;
+  tone?: 'default' | 'success' | 'warning';
+}
+
+export function Tag({ children }: TagProps) {
+  return (
+    <span className={styles.tag}>
+      <span className={styles.dot} aria-hidden />
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/Window.module.css
+++ b/src/components/ui/Window.module.css
@@ -1,0 +1,55 @@
+.window {
+  background: rgba(10, 10, 18, 0.85);
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+  backdrop-filter: blur(14px);
+}
+
+.titleBar {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.75rem 1rem;
+  background: linear-gradient(90deg, rgba(255, 0, 102, 0.2), rgba(0, 102, 255, 0.1));
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.control {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--br-hot-pink);
+  box-shadow: 12px 0 0 var(--br-warm), 24px 0 0 var(--br-cyber-blue);
+}
+
+.title {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--br-text);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.body {
+  padding: 1.1rem 1.2rem 1.25rem;
+  color: var(--br-text);
+  font-family: var(--br-font-mono);
+  line-height: 1.6;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 0, 102, 0.08), transparent 35%),
+    radial-gradient(circle at 80% 0%, rgba(0, 102, 255, 0.1), transparent 40%),
+    rgba(255, 255, 255, 0.01);
+}
+
+.subtitle {
+  color: var(--muted);
+  margin-top: 0.35rem;
+}

--- a/src/components/ui/Window.tsx
+++ b/src/components/ui/Window.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+import styles from './Window.module.css';
+
+interface WindowProps {
+  title: string;
+  icon?: ReactNode;
+  subtitle?: string;
+  children: ReactNode;
+}
+
+export function Window({ title, icon, subtitle, children }: WindowProps) {
+  return (
+    <div className={styles.window}>
+      <div className={styles.titleBar}>
+        <div className={styles.controls} aria-hidden>
+          <span className={styles.control} />
+        </div>
+        <div>
+          <p className={styles.title}>
+            {icon}
+            {title}
+          </p>
+          {subtitle ? <p className={styles.subtitle}>{subtitle}</p> : null}
+        </div>
+      </div>
+      <div className={styles.body}>{children}</div>
+    </div>
+  );
+}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,13 +1,16 @@
+export const DOCS_URL = process.env.NEXT_PUBLIC_DOCS_URL || 'https://docs.blackroad.systems';
+export const PRISM_URL = process.env.NEXT_PUBLIC_PRISM_URL || 'https://prism.blackroad.systems';
+export const CONTACT_URL =
+  process.env.NEXT_PUBLIC_CONTACT_URL || 'mailto:blackroad.systems@gmail.com?subject=BlackRoad%20OS%20intro';
+
 export const NAV_LINKS = [
-  { href: '/', label: 'Home' },
-  { href: '/product', label: 'Product' },
-  { href: '/pricing', label: 'Pricing' },
-  { href: '/regulated', label: 'Regulated' },
-  { href: '/about', label: 'About' },
-  { href: '/contact', label: 'Contact' }
+  { href: '/', label: 'Product', external: false },
+  { href: '/stack', label: 'Stack', external: false },
+  { href: DOCS_URL, label: 'Docs', external: true },
+  { href: PRISM_URL, label: 'Prism Console', external: true },
+  { href: CONTACT_URL, label: 'Contact', external: true }
 ];
 
-export const DOCS_URL = process.env.NEXT_PUBLIC_DOCS_URL || 'https://docs.blackroad.systems';
 export const GITHUB_URL = 'https://github.com/blackroadlabs/blackroad-os-web';
-export const CTA_LABEL = 'Request Early Access';
-export const CTA_DESTINATION = '/contact';
+export const CTA_LABEL = 'Open Prism Console';
+export const CTA_DESTINATION = PRISM_URL;

--- a/src/lib/stackMap.ts
+++ b/src/lib/stackMap.ts
@@ -1,0 +1,82 @@
+export type StackLayer = 'Core' | 'Runtime' | 'Interface' | 'Infra' | 'Docs' | 'Agents';
+
+export interface StackComponent {
+  id: string;
+  name: string;
+  repo: string;
+  layer: StackLayer;
+  description: string;
+  status: 'planned' | 'alpha' | 'beta' | 'prod';
+  links?: {
+    github?: string;
+    docs?: string;
+    console?: string;
+  };
+}
+
+export const STACK_COMPONENTS: StackComponent[] = [
+  {
+    id: 'core',
+    name: 'blackroad-os-core',
+    repo: 'BlackRoad-OS/blackroad-os-core',
+    layer: 'Core',
+    status: 'alpha',
+    description: 'Domain primitives: PS-SHA∞ identity, truth, events, agents, jobs.'
+  },
+  {
+    id: 'operator',
+    name: 'blackroad-os-operator',
+    repo: 'BlackRoad-OS/blackroad-os-operator',
+    layer: 'Runtime',
+    status: 'alpha',
+    description: 'Automation runtime that runs agents and jobs, emits events.'
+  },
+  {
+    id: 'api',
+    name: 'blackroad-os-api',
+    repo: 'BlackRoad-OS/blackroad-os-api',
+    layer: 'Runtime',
+    status: 'alpha',
+    description: 'Typed HTTP surface for Prism Console and other clients.'
+  },
+  {
+    id: 'prism',
+    name: 'blackroad-os-prism-console',
+    repo: 'BlackRoad-OS/blackroad-os-prism-console',
+    layer: 'Interface',
+    status: 'alpha',
+    description: 'Operator console for agents, finance, and RoadChain events.'
+  },
+  {
+    id: 'web',
+    name: 'blackroad-os-web',
+    repo: 'BlackRoad-OS/blackroad-os-web',
+    layer: 'Interface',
+    status: 'alpha',
+    description: 'Public face of BlackRoad OS with the desktop shell experience.'
+  },
+  {
+    id: 'infra',
+    name: 'blackroad-os-infra',
+    repo: 'BlackRoad-OS/blackroad-os-infra',
+    layer: 'Infra',
+    status: 'alpha',
+    description: 'DNS, environments, deployment and runbooks.'
+  },
+  {
+    id: 'docs',
+    name: 'blackroad-os-docs',
+    repo: 'BlackRoad-OS/blackroad-os-docs',
+    layer: 'Docs',
+    status: 'alpha',
+    description: 'Canonical documentation for the OS and its components.'
+  },
+  {
+    id: 'agents',
+    name: 'Lucidia, Atlas & friends',
+    repo: '',
+    layer: 'Agents',
+    status: 'planned',
+    description: 'Specialized agents orchestrated via Operator and Core primitives.'
+  }
+];


### PR DESCRIPTION
## Summary
- introduce desktop-inspired hero experience with new UI primitives (Window, Card, Button, Tag) and DesktopShell visualization
- add stack map, use cases, seasons roadmap, and CTA sections powered by env-aware links to Prism, Docs, and Contact
- centralize brand tokens and update README with environment details and repo relationships

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69238bcec9c483298d9e96e4c31a6049)