### PR TITLE
Add branded operator console, roadchain, and agent dashboards

### DIFF
--- a/app/agents/page.tsx
+++ b/app/agents/page.tsx
@@ -1,0 +1,134 @@
+import styles from '../styles/os-shell.module.css';
+
+const agents = [
+  {
+    name: 'Aurora',
+    role: 'Finance · FP&A',
+    status: 'Executing',
+    tone: 'success',
+    load: 78,
+    memory: 'Synced',
+    events: 'Recent: runway stress test + budget patch'
+  },
+  {
+    name: 'Orbit',
+    role: 'Legal · Governance',
+    status: 'Awaiting approval',
+    tone: 'warn',
+    load: 52,
+    memory: 'Checkpointed',
+    events: 'Drafting vendor clause upgrade'
+  },
+  {
+    name: 'Relay',
+    role: 'Ops · Supply',
+    status: 'Executing',
+    tone: 'info',
+    load: 64,
+    memory: 'Synced',
+    events: 'Reconciling freight anomalies'
+  }
+];
+
+const stats = [
+  { label: 'Active agents', value: '48', meta: 'Clustered across 6 zones' },
+  { label: 'Tasks in flight', value: '187', meta: 'governed + journaled' },
+  { label: 'Memory sync', value: '99.4%', meta: 'JetBrains Mono channels' }
+];
+
+export default function AgentsPage() {
+  return (
+    <div className={styles.page}>
+      <div className={styles.canvas}>
+        <section className={styles.hero}>
+          <span className={styles.pill}>
+            <span className={styles.pillSwatch} /> Agent fabric
+          </span>
+          <h1 className={styles.title}>Agent dashboard</h1>
+          <p className={styles.subtitle}>
+            Monitor active agents, memory sync, and task progression. Design tokens mirror the BR → OS
+            gradient and golden-ratio grid for clarity.
+          </p>
+
+          <div className={styles.metricsRow}>
+            {stats.map((stat) => (
+              <div key={stat.label} className={styles.metricCard}>
+                <span className={styles.metricLabel}>{stat.label}</span>
+                <div className={styles.metricValue}>{stat.value}</div>
+                <div className={styles.metricMeta}>{stat.meta}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.goldenGrid}>
+          <div className={styles.panel}>
+            <div className={styles.panelHeader}>
+              <h2 className={styles.panelTitle}>Active agents</h2>
+              <span className={`${styles.statusPill} ${styles.statusSuccess}`}>Aligned</span>
+            </div>
+            <div className={styles.gridRow}>
+              {agents.map((agent) => (
+                <div key={agent.name} className={styles.agentCard}>
+                  <div className={styles.agentHeader}>
+                    <div className={styles.avatar}>{agent.name[0]}</div>
+                    <div>
+                      <h3 className={styles.agentName}>{agent.name}</h3>
+                      <div className={styles.agentMeta}>{agent.role}</div>
+                    </div>
+                  </div>
+
+                  <div className={styles.agentMeta}>
+                    <span className={`${styles.statusPill} ${
+                      agent.tone === 'success'
+                        ? styles.statusSuccess
+                        : agent.tone === 'warn'
+                          ? styles.statusWarn
+                          : styles.statusInfo
+                    }`}>
+                      {agent.status}
+                    </span>
+                    <span className={styles.miniTag}>Memory: {agent.memory}</span>
+                    <span className={styles.miniTag}>JetBrains Mono</span>
+                  </div>
+
+                  <div className={styles.panelMeta}>{agent.events}</div>
+
+                  <div className={styles.agentFooter}>
+                    <div className={styles.progressBar}>
+                      <div className={styles.progressFill} style={{ width: `${agent.load}%` }} />
+                    </div>
+                    <span className={styles.panelMeta}>{agent.load}% load</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className={styles.panel}>
+            <div className={styles.panelHeader}>
+              <h2 className={styles.panelTitle}>Recent events</h2>
+              <span className={`${styles.statusPill} ${styles.statusInfo}`}>Synced</span>
+            </div>
+            <ul className={styles.feedList}>
+              <li className={styles.feedItem}>
+                <strong>Memory sync</strong>
+                <span className={styles.panelMeta}>Updated embeddings shared to Roadchain ledger.</span>
+              </li>
+              <li className={styles.feedItem}>
+                <strong>Guardrails</strong>
+                <span className={styles.panelMeta}>
+                  Safety harness patched with new policy lattice; approvals tracked per agent.
+                </span>
+              </li>
+              <li className={styles.feedItem}>
+                <strong>Operator</strong>
+                <span className={styles.panelMeta}>Console acknowledged · ready for overrides.</span>
+              </li>
+            </ul>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/console/page.tsx
+++ b/app/console/page.tsx
@@ -1,15 +1,207 @@
-import { InfoCard } from '@/components/primitives/InfoCard';
-import styles from '../page.module.css';
+import styles from '../styles/os-shell.module.css';
+
+const metrics = [
+  { label: 'Orchestrated tasks', value: '12,480', meta: 'last 24h across all agents' },
+  { label: 'Human approvals', value: '42', meta: 'pending 3, completed 39' },
+  { label: 'Ledger coverage', value: '99.2%', meta: 'PS-SHA∞ journaling uptime' }
+];
+
+const modules = [
+  {
+    name: 'Prism Observer',
+    context: 'live traces + audit mirrors',
+    status: 'Stable',
+    statusTone: 'success'
+  },
+  {
+    name: 'RoadWallet',
+    context: 'treasury + disbursement controls',
+    status: 'Guarded',
+    statusTone: 'warn'
+  },
+  {
+    name: 'Policy Router',
+    context: 'approval lattice + safeties',
+    status: 'Tuned',
+    statusTone: 'info'
+  },
+  {
+    name: 'Compute Mesh',
+    context: 'zones: 6 · autoscaling on',
+    status: 'Nominal',
+    statusTone: 'success'
+  }
+];
+
+const toggles = [
+  {
+    title: 'Darkline mode',
+    copy: 'Mask secrets in console playback + enforce hardware keys.',
+    badge: 'Critical',
+    state: 'Enabled'
+  },
+  {
+    title: 'Orchestration overrides',
+    copy: 'Pause speculative tasks when human approvals exceed threshold.',
+    badge: 'Policy',
+    state: 'Auto'
+  },
+  {
+    title: 'Telemetry beacons',
+    copy: 'Send live traces to regulators with signed diffs.',
+    badge: 'Observability',
+    state: 'Live'
+  }
+];
+
+const queue = [
+  {
+    id: 'task-8842',
+    summary: 'Agent Finance.FP&A generating live P&L',
+    owner: 'FP&A / Aurora',
+    state: 'Ready',
+    tone: 'success'
+  },
+  {
+    id: 'task-8839',
+    summary: 'Legal.Governance drafting vendor review addendum',
+    owner: 'Legal / Orbit',
+    state: 'Awaiting approval',
+    tone: 'warn'
+  },
+  {
+    id: 'task-8832',
+    summary: 'Ops.Supply reconciling freight anomalies',
+    owner: 'Ops / Relay',
+    state: 'Executing',
+    tone: 'info'
+  }
+];
 
 export default function ConsolePage() {
   return (
     <div className={styles.page}>
-      <InfoCard
-        title="Console"
-        description="Extend this space with live agent monitoring, logs, and admin controls."
-      >
-        <p className="muted">Wire your console UI here.</p>
-      </InfoCard>
+      <div className={styles.canvas}>
+        <section className={styles.hero}>
+          <span className={styles.pill}>
+            <span className={styles.pillSwatch} /> Prism Console
+          </span>
+          <h1 className={styles.title}>Operator console</h1>
+          <p className={styles.subtitle}>
+            Govern every agent, queue, and approval from a single pane. Built for precision, fast
+            routing, and human-first overrides.
+          </p>
+
+          <div className={styles.metricsRow}>
+            {metrics.map((metric) => (
+              <div key={metric.label} className={styles.metricCard}>
+                <span className={styles.metricLabel}>{metric.label}</span>
+                <div className={styles.metricValue}>{metric.value}</div>
+                <div className={styles.metricMeta}>{metric.meta}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.goldenGrid}>
+          <div className={styles.panel}>
+            <div className={styles.panelHeader}>
+              <h2 className={styles.panelTitle}>Active modules</h2>
+              <span className={`${styles.statusPill} ${styles.statusSuccess}`}>Stable</span>
+            </div>
+            <div className={styles.listStack}>
+              {modules.map((module) => (
+                <div key={module.name} className={styles.listRow}>
+                  <strong>{module.name}</strong>
+                  <span className={styles.panelMeta}>{module.context}</span>
+                  <span className={styles.badge}>Golden-ratio grid aligned</span>
+                  <span
+                    className={`${styles.statusPill} ${
+                      module.statusTone === 'success'
+                        ? styles.statusSuccess
+                        : module.statusTone === 'warn'
+                          ? styles.statusWarn
+                          : styles.statusInfo
+                    }`}
+                  >
+                    {module.status}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className={styles.panel}>
+            <div className={styles.panelHeader}>
+              <h2 className={styles.panelTitle}>Controls</h2>
+              <span className={`${styles.statusPill} ${styles.statusInfo}`}>Realtime</span>
+            </div>
+            <div className={styles.listStack}>
+              {toggles.map((toggle) => (
+                <div key={toggle.title} className={styles.toggleRow}>
+                  <div className={styles.toggleCopy}>
+                    <span className={styles.smallLabel}>{toggle.badge}</span>
+                    <span className={styles.accentText}>{toggle.title}</span>
+                    <span className={styles.panelMeta}>{toggle.copy}</span>
+                  </div>
+                  <span className={`${styles.statusPill} ${styles.statusSuccess}`}>{toggle.state}</span>
+                </div>
+              ))}
+            </div>
+            <div className={styles.tagRow}>
+              <a className={styles.primaryButton} href="/roadchain">
+                View ledger
+              </a>
+              <a className={styles.secondaryButton} href="/agents">
+                Manage agents
+              </a>
+            </div>
+          </div>
+        </section>
+
+        <section className={styles.gridRow}>
+          <div className={styles.card}>
+            <h3 className={styles.cardTitle}>Queue & approvals</h3>
+            <div className={styles.stack}>
+              {queue.map((item) => (
+                <div key={item.id} className={styles.listRow}>
+                  <div>
+                    <strong className={styles.mono}>{item.id}</strong>
+                    <div className={styles.panelMeta}>{item.summary}</div>
+                  </div>
+                  <span className={styles.panelMeta}>{item.owner}</span>
+                  <span className={styles.badge}>Audit tagged</span>
+                  <span
+                    className={`${styles.statusPill} ${
+                      item.tone === 'success'
+                        ? styles.statusSuccess
+                        : item.tone === 'warn'
+                          ? styles.statusWarn
+                          : styles.statusInfo
+                    }`}
+                  >
+                    {item.state}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className={styles.card}>
+            <h3 className={styles.cardTitle}>Health pulse</h3>
+            <p className={styles.cardText}>
+              Live telemetry keeps orchestrators in control. Roadchain diffs, compute heat, and policy
+              thresholds stay visible without distracting from execution speed.
+            </p>
+            <div className={styles.tagRow}>
+              <span className={styles.miniTag}>BR→OS gradient</span>
+              <span className={styles.miniTag}>JetBrains Mono</span>
+              <span className={styles.miniTag}>1120px canvas</span>
+              <span className={styles.miniTag}>Tier 1 radius 24px</span>
+            </div>
+          </div>
+        </section>
+      </div>
     </div>
   );
 }

--- a/app/login/LoginPage.module.css
+++ b/app/login/LoginPage.module.css
@@ -464,6 +464,66 @@
   box-shadow: 0 12px 26px rgba(0, 0, 0, 0.9);
 }
 
+.ssoGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 10px;
+  margin: 4px 0 6px;
+}
+
+.secondaryButton {
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(0, 0, 0, 0.6);
+  border-radius: 999px;
+  padding: 10px 12px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--br-text);
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: 0 12px 22px rgba(0, 0, 0, 0.55);
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.secondaryButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 30px rgba(0, 0, 0, 0.7);
+}
+
+.walletButton {
+  background: linear-gradient(145deg, rgba(255, 157, 0, 0.2), rgba(119, 0, 255, 0.15));
+}
+
+.ssoBadge {
+  padding: 6px 10px;
+  border-radius: 10px;
+  background: var(--br-grad-full);
+  color: #020006;
+  font-weight: 800;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  box-shadow: 0 0 0 1px #000;
+}
+
+.ssoCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: flex-start;
+}
+
+.ssoTitle {
+  font-size: 12px;
+}
+
+.ssoHint {
+  font-size: 11px;
+  color: var(--br-text-subtle);
+}
+
 .divider {
   display: flex;
   align-items: center;

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -134,6 +134,24 @@ export default function LoginPage() {
                   </a>
                 </div>
 
+                <div className={styles.ssoGrid}>
+                  <button type="button" className={styles.secondaryButton}>
+                    <div className={styles.ssoBadge}>BR · SSO</div>
+                    <div className={styles.ssoCopy}>
+                      <span className={styles.ssoTitle}>BlackRoad SSO</span>
+                      <span className={styles.ssoHint}>Route through the identity layer</span>
+                    </div>
+                  </button>
+
+                  <button type="button" className={`${styles.secondaryButton} ${styles.walletButton}`}>
+                    <div className={styles.ssoBadge}>RoadWallet</div>
+                    <div className={styles.ssoCopy}>
+                      <span className={styles.ssoTitle}>Wallet SSO</span>
+                      <span className={styles.ssoHint}>Hardware-backed session attestation</span>
+                    </div>
+                  </button>
+                </div>
+
                 <button type="submit" className={styles.primaryButton}>
                   Enter operating system
                   <span className={styles.kbd}>↵</span>

--- a/app/roadchain/page.tsx
+++ b/app/roadchain/page.tsx
@@ -1,0 +1,121 @@
+import styles from '../styles/os-shell.module.css';
+
+const ledgerBlocks = [
+  {
+    height: '#2841',
+    timestamp: '2024-06-11T16:08:24Z',
+    agent: 'Finance.FP&A',
+    hash: '0x9fe2-3b17-7c11-88ac-0024-0a2b',
+    summary: 'Scenario run: Q3 runway stress test',
+    status: 'Committed'
+  },
+  {
+    height: '#2840',
+    timestamp: '2024-06-11T16:04:12Z',
+    agent: 'Ops.Supply',
+    hash: '0xc02d-472f-11ed-bcdc-0242-ac15',
+    summary: 'Freight anomaly replay · safe fallback enabled',
+    status: 'Guarded'
+  },
+  {
+    height: '#283F',
+    timestamp: '2024-06-11T15:57:03Z',
+    agent: 'Legal.Governance',
+    hash: '0x7bc0-1fd5-4e27-b39f-92d4-2044',
+    summary: 'Vendor policy delta notarized',
+    status: 'Committed'
+  }
+];
+
+const feed = [
+  'New diff signature detected · replay ready',
+  'Ledger sync: 6 zones converged',
+  'PS-SHA∞ attestation posted to regulator endpoint',
+  'Audit mirror refreshed · 13ms behind realtime'
+];
+
+const diffs = [
+  {
+    title: 'Audit hooks',
+    copy: 'Every action hashed with lineage, approvals, and origin agent metadata.'
+  },
+  {
+    title: 'RoadWallet state',
+    copy: 'Outbound disbursements gated by dual-control + hardware key requirement.'
+  },
+  {
+    title: 'Console sync',
+    copy: 'Prism Console receives signed event mirrors for operator awareness.'
+  }
+];
+
+export default function RoadchainPage() {
+  return (
+    <div className={styles.page}>
+      <div className={styles.canvas}>
+        <section className={styles.hero}>
+          <span className={styles.pill}>
+            <span className={styles.pillSwatch} /> Roadchain ledger
+          </span>
+          <h1 className={styles.title}>Immutable operator timeline</h1>
+          <p className={styles.subtitle}>
+            Every agent action, approval, and diff is captured with the BR → OS gradient lineage. Review
+            blocks, hashes, and summaries in a golden-ratio canvas built for speed.
+          </p>
+        </section>
+
+        <section className={styles.goldenGrid}>
+          <div className={styles.panel}>
+            <div className={styles.panelHeader}>
+              <h2 className={styles.panelTitle}>Blocks</h2>
+              <span className={`${styles.statusPill} ${styles.statusSuccess}`}>Live</span>
+            </div>
+            <div className={styles.ledgerList}>
+              {ledgerBlocks.map((block) => (
+                <div key={block.hash} className={styles.ledgerCard}>
+                  <div className={styles.ledgerMeta}>
+                    <span className={styles.badge}>Height {block.height}</span>
+                    <span className={styles.badge}>{block.agent}</span>
+                    <span className={`${styles.statusPill} ${styles.statusInfo}`}>{block.timestamp}</span>
+                  </div>
+                  <div className={styles.ledgerHash}>{block.hash}</div>
+                  <div className={styles.panelMeta}>{block.summary}</div>
+                  <span className={`${styles.statusPill} ${styles.statusSuccess}`}>{block.status}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className={styles.panel}>
+            <div className={styles.panelHeader}>
+              <h2 className={styles.panelTitle}>Live feed</h2>
+              <span className={`${styles.statusPill} ${styles.statusInfo}`}>Streaming</span>
+            </div>
+            <ul className={styles.feedList}>
+              {feed.map((item) => (
+                <li key={item} className={styles.feedItem}>
+                  <strong>Event</strong>
+                  <span className={styles.panelMeta}>{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        <section className={styles.gridRow}>
+          {diffs.map((diff) => (
+            <div key={diff.title} className={styles.card}>
+              <h3 className={styles.cardTitle}>{diff.title}</h3>
+              <p className={styles.cardText}>{diff.copy}</p>
+              <div className={styles.tagRow}>
+                <span className={styles.miniTag}>Hash-linked</span>
+                <span className={styles.miniTag}>1120px canvas</span>
+                <span className={styles.miniTag}>Tier 2 radius 18px</span>
+              </div>
+            </div>
+          ))}
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/styles/os-shell.module.css
+++ b/app/styles/os-shell.module.css
@@ -1,0 +1,449 @@
+.page {
+  padding: 48px 0 88px;
+}
+
+.canvas {
+  width: min(1120px, 96vw);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  color: var(--br-text-subtle);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 11px;
+  backdrop-filter: blur(8px);
+}
+
+.pillSwatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 10px;
+  background: var(--br-grad-full);
+  box-shadow: 0 0 0 1px #000;
+}
+
+.title {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  letter-spacing: -0.03em;
+  margin: 0;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--br-text-subtle);
+  max-width: 720px;
+  line-height: 1.6;
+}
+
+.metricsRow {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+}
+
+.metricCard {
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 18px;
+  padding: 14px 16px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.metricLabel {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  color: var(--br-text-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 11px;
+}
+
+.metricValue {
+  font-size: 1.4rem;
+  font-weight: 800;
+  margin: 6px 0 2px;
+}
+
+.metricMeta {
+  color: var(--br-text-subtle);
+  font-size: 0.95rem;
+}
+
+.goldenGrid {
+  display: grid;
+  grid-template-columns: 1.618fr 1fr;
+  gap: 16px;
+  align-items: start;
+}
+
+.panel {
+  background: linear-gradient(160deg, rgba(10, 10, 18, 0.95), rgba(3, 1, 10, 0.95));
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 24px;
+  padding: 18px 18px 16px;
+  box-shadow:
+    0 22px 48px rgba(0, 0, 0, 0.78),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.panelHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+}
+
+.panelTitle {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.panelMeta {
+  color: var(--br-text-faint);
+  font-size: 0.9rem;
+}
+
+.listStack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.listRow {
+  display: grid;
+  grid-template-columns: 1.4fr 0.9fr 0.9fr auto;
+  gap: 10px;
+  align-items: center;
+  padding: 12px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.listRow strong {
+  font-weight: 800;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 0.9rem;
+}
+
+.mono {
+  font-family: var(--br-font-mono);
+  letter-spacing: 0.02em;
+}
+
+.statusPill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(255, 255, 255, 0.05);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 11px;
+}
+
+.statusSuccess {
+  color: #29cc7a;
+  border-color: rgba(41, 204, 122, 0.3);
+  box-shadow: 0 0 24px rgba(41, 204, 122, 0.28);
+}
+
+.statusWarn {
+  color: #ffb020;
+  border-color: rgba(255, 176, 32, 0.3);
+  box-shadow: 0 0 24px rgba(255, 176, 32, 0.28);
+}
+
+.statusError {
+  color: #ff4477;
+  border-color: rgba(255, 68, 119, 0.35);
+  box-shadow: 0 0 24px rgba(255, 68, 119, 0.32);
+}
+
+.statusInfo {
+  color: #4dd4ff;
+  border-color: rgba(77, 212, 255, 0.35);
+  box-shadow: 0 0 24px rgba(77, 212, 255, 0.32);
+}
+
+.toggleRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 12px 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.toggleCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.smallLabel {
+  color: var(--br-text-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 10px;
+}
+
+.accentText {
+  color: var(--br-text);
+  font-weight: 700;
+}
+
+.primaryButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: var(--br-grad-full);
+  color: #020008;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  text-decoration: none;
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.65), 0 0 0 1px #000;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.primaryButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 44px rgba(0, 0, 0, 0.7);
+}
+
+.secondaryButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--br-text);
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-decoration: none;
+}
+
+.gridRow {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.card {
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.cardTitle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0 0 6px;
+  font-size: 1rem;
+}
+
+.cardText {
+  margin: 0;
+  color: var(--br-text-subtle);
+  line-height: 1.6;
+}
+
+.tagRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.miniTag {
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  font-size: 12px;
+}
+
+.ledgerList {
+  display: grid;
+  gap: 12px;
+}
+
+.ledgerCard {
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0));
+  padding: 14px;
+  display: grid;
+  gap: 8px;
+}
+
+.ledgerMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--br-text-subtle);
+}
+
+.ledgerHash {
+  font-family: var(--br-font-mono);
+  background: rgba(255, 255, 255, 0.05);
+  padding: 6px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  word-break: break-all;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.agentCard {
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0));
+  padding: 14px 14px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  position: relative;
+  overflow: hidden;
+}
+
+.agentCard::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 0, 102, 0.12), transparent 46%);
+  pointer-events: none;
+}
+
+.agentHeader {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: var(--br-grad-full);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 900;
+  color: #020008;
+  box-shadow: 0 0 0 1px #000, 0 16px 28px rgba(0, 0, 0, 0.55);
+}
+
+.agentName {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.agentMeta {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  color: var(--br-text-faint);
+  font-size: 12px;
+}
+
+.agentFooter {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+}
+
+.progressBar {
+  width: 100%;
+  height: 8px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.05);
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.progressFill {
+  height: 100%;
+  background: var(--br-grad-full);
+}
+
+.feedList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.feedItem {
+  padding: 12px;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.feedItem strong {
+  display: block;
+  margin-bottom: 6px;
+}
+
+@media (max-width: 960px) {
+  .goldenGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .listRow {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -3,6 +3,9 @@ export const NAV_LINKS = [
   { href: '/product', label: 'Product' },
   { href: '/pricing', label: 'Pricing' },
   { href: '/regulated', label: 'Regulated' },
+  { href: '/console', label: 'Console' },
+  { href: '/roadchain', label: 'Roadchain' },
+  { href: '/agents', label: 'Agents' },
   { href: '/about', label: 'About' },
   { href: '/contact', label: 'Contact' }
 ];


### PR DESCRIPTION
## Summary
- add Prism console layout with golden-ratio grids, controls, and queue visuals using BR→OS gradients
- introduce Roadchain explorer and agent dashboard pages with ledger streams, agent badges, and brand-aligned metrics
- centralize shell styling tokens for panels, pills, and gradients plus login SSO options for BR and RoadWallet

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923901daa4c83298a1f63b7e3dfbf60)