### PR TITLE
Add vision, docs, and company pages

### DIFF
--- a/app/company/page.tsx
+++ b/app/company/page.tsx
@@ -1,0 +1,88 @@
+import type { Metadata } from 'next';
+import { CTASection } from '@/components/CTASection';
+import { SplitSection } from '@/components/SplitSection';
+import styles from '../marketing.module.css';
+
+export const metadata: Metadata = {
+  title: 'Company | BlackRoad OS',
+  description: 'BlackRoad OS Inc. builds the public face of the Road—contact, trademark, and domain information for partners and press.',
+  openGraph: {
+    title: 'Company | BlackRoad OS',
+    description: 'Learn about BlackRoad OS Inc., how to reach us, and how the brand stays compliant across domains and trademarks.'
+  },
+  twitter: {
+    title: 'Company | BlackRoad OS',
+    description: 'Reach BlackRoad OS Inc. for partnerships, press, and enterprise engagements.'
+  }
+};
+
+const contactChannels = ['hello@blackroad.systems', 'blackroados@gmail.com', 'blackroados@outlook.com', 'blackroados@yahoo.com'];
+
+export default function CompanyPage() {
+  return (
+    <div>
+      <header className={`section ${styles.pageHeader}`}>
+        <div className="section-inner">
+          <div className={styles.tagRow}>
+            <span className={styles.pill}>Company</span>
+            <span className={styles.pill}>Contact</span>
+          </div>
+          <h1 className="section-title">BlackRoad OS Inc.</h1>
+          <p className={styles.lead}>
+            We steward the public-facing website for BlackRoad OS—the neon horizon where partners, investors, and the community
+            meet the Agent Mesh. For product access, compliance reviews, or media inquiries, use the channels below.
+          </p>
+        </div>
+      </header>
+
+      <section className="section">
+        <div className="section-inner card-grid">
+          <div className="card">
+            <h3>Company summary</h3>
+            <p className="muted">
+              BlackRoad OS Inc. develops the story layer for the Road, aligning SIG, PS-SHA∞, and Lucidia narratives with the
+              regulated realities of modern enterprises.
+            </p>
+          </div>
+          <div className="card">
+            <h3>Brand + domains</h3>
+            <p className="muted">
+              We maintain the BlackRoad OS trademark positioning and the primary domain portfolio, including blackroad.systems
+              and linked product surfaces.
+            </p>
+          </div>
+          <div className="card">
+            <h3>Contact channels</h3>
+            <ul className="list-disc">
+              {contactChannels.map((email) => (
+                <li key={email}>{email}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <SplitSection
+        eyebrow="Public front door"
+        title="From narrative to engagement"
+        description="This site is the handshake into BlackRoad OS—linking Prism Console, Operator, and Core while keeping compliance and brand fidelity intact."
+        bullets={[
+          'Gateway into docs, console, and roadmap updates.',
+          'Clear points of contact for enterprise diligence and partnerships.',
+          'BlackRoad aesthetic: dark, sharp, neon edges with BR→OS gradients.'
+        ]}
+        visualTitle="Audit-ready surface"
+        visualCopy="We align messaging with PS-SHA∞ journaling and make sure every outbound touchpoint reflects the truth-first design of the platform."
+      />
+
+      <CTASection
+        title="Talk to BlackRoad OS"
+        copy="Reach out for enterprise engagements, media coordination, or to validate SIG + PS-SHA∞ approaches for your stack."
+        primaryLabel="Email the team"
+        primaryHref="mailto:hello@blackroad.systems"
+        secondaryLabel="View docs"
+        secondaryHref="/docs"
+      />
+    </div>
+  );
+}

--- a/app/docs/page.tsx
+++ b/app/docs/page.tsx
@@ -1,0 +1,104 @@
+import type { Metadata } from 'next';
+import { CTASection } from '@/components/CTASection';
+import styles from '../marketing.module.css';
+
+export const metadata: Metadata = {
+  title: 'Docs | BlackRoad OS',
+  description: 'Gateway into BlackRoad OS documentation, linking to Prism Console and Core repositories for deeper implementation details.',
+  openGraph: {
+    title: 'Docs | BlackRoad OS',
+    description: 'Start from the BlackRoad OS docs entry point to reach Prism Console, Operator, and Core readmes.'
+  },
+  twitter: {
+    title: 'Docs | BlackRoad OS',
+    description: 'BlackRoad OS docs entry point for Prism Console, Operator, and Core readmes.'
+  }
+};
+
+const docLinks = [
+  {
+    title: 'Prism Console',
+    description: 'Operational console, approvals, and observability for the Agent Mesh.',
+    href: 'https://github.com/blackroadlabs/blackroad-os-prism-console'
+  },
+  {
+    title: 'blackroad-os-core',
+    description: 'Ledger-native event bus, journaling, and policies for agent orchestration.',
+    href: 'https://github.com/blackroadlabs/blackroad-os-core'
+  },
+  {
+    title: 'blackroad-os-operator',
+    description: 'Scheduling, policy enforcement, and task routing across thousands of agents.',
+    href: 'https://github.com/blackroadlabs/blackroad-os-operator'
+  }
+];
+
+export default function DocsPage() {
+  return (
+    <div>
+      <header className={`section ${styles.pageHeader}`}>
+        <div className="section-inner">
+          <div className={styles.tagRow}>
+            <span className={styles.pill}>Docs</span>
+            <span className={styles.pill}>Gateway</span>
+          </div>
+          <h1 className="section-title">Documentation entry point</h1>
+          <p className={styles.lead}>
+            This is the front door into BlackRoad OS documentation. Jump to the Prism Console README for the UI surface, explore
+            operator internals, or review the core ledger and journaling primitives.
+          </p>
+        </div>
+      </header>
+
+      <section className="section">
+        <div className="section-inner card-grid">
+          {docLinks.map((link) => (
+            <div className="card" key={link.title}>
+              <h3>{link.title}</h3>
+              <p className="muted">{link.description}</p>
+              <p>
+                <a className="cta-button secondary" href={link.href} target="_blank" rel="noreferrer">
+                  Open README
+                </a>
+              </p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="section">
+        <div className="section-inner">
+          <div className={styles.callout}>
+            <strong>SEO + metadata.</strong> Each downstream repo maintains its own OpenGraph and Twitter metadata. This gateway
+            page keeps the narrative aligned while linking you directly to authoritative sources.
+          </div>
+          <div className="card-grid">
+            <div className="card">
+              <h3>Request access</h3>
+              <p className="muted">
+                Need guided onboarding, compliance mappings, or a tailored architecture session? Talk to the team and we will align
+                the docs to your environment.
+              </p>
+            </div>
+            <div className="card">
+              <h3>Stay in the loop</h3>
+              <p className="muted">
+                Follow releases across Operator, Core, and Prism Console. The Road evolves quickly; this page keeps the outward
+                story coherent.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <CTASection
+        title="Step into the docs"
+        copy="Review the readmes, then connect with us to align SIG and PS-SHA∞ patterns to your operating model."
+        primaryLabel="Open Prism README"
+        primaryHref="https://github.com/blackroadlabs/blackroad-os-prism-console"
+        secondaryLabel="Talk to the team"
+        secondaryHref="/contact"
+      />
+    </div>
+  );
+}

--- a/app/vision/page.tsx
+++ b/app/vision/page.tsx
@@ -1,0 +1,101 @@
+import type { Metadata } from 'next';
+import { CTASection } from '@/components/CTASection';
+import { SplitSection } from '@/components/SplitSection';
+import styles from '../marketing.module.css';
+
+export const metadata: Metadata = {
+  title: 'Vision | BlackRoad OS',
+  description:
+    'Spiral Information Geometry, PS-SHA∞ identity, and Lucidia converge to form the BlackRoad Agent Mesh and public face of the Road.',
+  openGraph: {
+    title: 'Vision | BlackRoad OS',
+    description:
+      'See how Spiral Information Geometry and PS-SHA∞ identity give BlackRoad OS its neon horizon—governing agents with truth-first primitives.'
+  },
+  twitter: {
+    title: 'Vision | BlackRoad OS',
+    description:
+      'BlackRoad OS stitches SIG, PS-SHA∞, Lucidia, and the Agent Mesh into a governed fabric for intelligent agents.'
+  }
+};
+
+export default function VisionPage() {
+  return (
+    <div>
+      <header className={`section ${styles.pageHeader}`}>
+        <div className="section-inner">
+          <div className={styles.tagRow}>
+            <span className={styles.pill}>Vision</span>
+            <span className={styles.pill}>Philosophy</span>
+          </div>
+          <h1 className="section-title">The neon horizon where BlackRoad begins</h1>
+          <p className={styles.lead}>
+            BlackRoad OS is the public face of the Road—the story layer where Spiral Information Geometry (SIG), PS-SHA∞ identity,
+            and Lucidia&apos;s Agent Mesh are expressed for operators, partners, and the community.
+          </p>
+        </div>
+      </header>
+
+      <section className="section">
+        <div className="section-inner card-grid">
+          <div className="card">
+            <h3>Spiral Information Geometry</h3>
+            <p className="muted">
+              SIG arranges knowledge in a governed spiral—policies, prompts, and lineage stay coherent as agents traverse time,
+              domains, and escalating stakes.
+            </p>
+          </div>
+          <div className="card">
+            <h3>PS-SHA∞ Identity Layer</h3>
+            <p className="muted">
+              The PS-SHA∞ signature enforces identity, provenance, and auditability. Every action on the Road inherits cryptographic
+              lineage that regulators and customers can verify.
+            </p>
+          </div>
+          <div className="card">
+            <h3>Lucidia & the Agent Mesh</h3>
+            <p className="muted">
+              Lucidia is the intelligence substrate. QI-backed signals flow across the Agent Mesh so specialized agents can share
+              context without breaking trust boundaries.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <SplitSection
+        eyebrow="Spiral Information Geometry"
+        title="Structured truth for intelligent agents"
+        description="SIG keeps BlackRoad OS coherent. The spiral organizes prompts, policies, and journals so context compounds safely while operators stay in command."
+        bullets={[
+          'Context spirals outward with lineage preserved for replay and audit.',
+          'Policy envelopes travel with each task to keep agents aligned to human intent.',
+          'Fractal geometry guides how new domains and automations are added to the Road.'
+        ]}
+        visualTitle="Public face of the Road"
+        visualCopy="The neon gradient is a reminder: every surface of BlackRoad OS is truth-first, auditable, and ready for regulated missions."
+      />
+
+      <SplitSection
+        eyebrow="Lucidia, QI, and the Agent Mesh"
+        title="Collective intelligence with human oversight"
+        description="Lucidia orchestrates perception and reasoning while the Agent Mesh shares state responsibly. Humans approve thresholds; agents propagate evidence."
+        bullets={[
+          'QI signals route attention to the right agents without leaking sensitive payloads.',
+          'Mesh-aware observability means drift, anomalies, and intent changes are visible in Prism.',
+          'Operator controls cadence, segregation of duties, and PS-SHA∞ journal checkpoints.'
+        ]}
+        visualTitle="Governed collaboration"
+        visualCopy="One orchestrator directs thousands of agents while the Mesh records how each move was authorized, simulated, and promoted."
+      />
+
+      <CTASection
+        title="Explore the Road"
+        copy="Dive into the public narrative, review the journals, and step into Prism Console to see the Agent Mesh live."
+        primaryLabel="View Product"
+        primaryHref="/product"
+        secondaryLabel="Open Docs"
+        secondaryHref="/docs"
+      />
+    </div>
+  );
+}

--- a/src/components/Layout/NavBar.tsx
+++ b/src/components/Layout/NavBar.tsx
@@ -26,9 +26,6 @@ export function NavBar() {
               {link.label}
             </Link>
           ))}
-          <a className={styles.navLink} href={DOCS_URL} target="_blank" rel="noreferrer">
-            Docs
-          </a>
         </div>
 
         <div className={styles.actions}>

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,9 +1,12 @@
 export const NAV_LINKS = [
   { href: '/', label: 'Home' },
   { href: '/product', label: 'Product' },
+  { href: '/vision', label: 'Vision' },
+  { href: '/docs', label: 'Docs' },
   { href: '/pricing', label: 'Pricing' },
   { href: '/regulated', label: 'Regulated' },
   { href: '/about', label: 'About' },
+  { href: '/company', label: 'Company' },
   { href: '/contact', label: 'Contact' }
 ];
 


### PR DESCRIPTION
## Summary
- add Vision page outlining SIG, PS-SHA∞, and Lucidia narrative with calls to action
- create Docs gateway page that links to Prism Console, Operator, and Core readmes
- introduce Company page with contact channels and update navigation to include new surfaces

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923934b8fac8329889c3bbe6a92a42f)