### PR TITLE
Enhance health and version telemetry responses

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,10 +1,1 @@
-import { NextResponse } from 'next/server';
-
-export async function GET() {
-  const body = {
-    status: 'ok',
-    service: 'web'
-  };
-
-  return NextResponse.json(body, { status: 200 });
-}
+export { GET, dynamic } from '../../health/route';

--- a/app/health/route.ts
+++ b/app/health/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server';
+import { collectHealthPayload, identityHeaders } from '@/lib/observability';
 
-export const dynamic = 'force-static';
+export const dynamic = 'force-dynamic';
 
 export async function GET() {
-  return NextResponse.json({ status: 'ok', service: 'web' });
+  return NextResponse.json(collectHealthPayload(), { headers: identityHeaders });
 }

--- a/app/version/route.ts
+++ b/app/version/route.ts
@@ -1,16 +1,8 @@
 import { NextResponse } from 'next/server';
-import packageJson from '../../package.json';
-import { serviceConfig } from '@/config/serviceConfig';
-
-function collectVersionPayload() {
-  return {
-    service: serviceConfig.SERVICE_ID,
-    version: packageJson.version
-  };
-}
+import { collectVersionPayload, identityHeaders } from '@/lib/observability';
 
 export async function GET() {
-  return NextResponse.json(collectVersionPayload());
+  return NextResponse.json(collectVersionPayload(), { headers: identityHeaders });
 }
 
 export type VersionPayload = ReturnType<typeof collectVersionPayload>;

--- a/src/lib/observability.ts
+++ b/src/lib/observability.ts
@@ -1,0 +1,48 @@
+import packageJson from '../../package.json';
+import { appConfig } from '@/config';
+import { serviceConfig } from '@/config/serviceConfig';
+
+const startedAt = Date.now();
+
+function resolveGitCommit() {
+  return process.env.VERCEL_GIT_COMMIT_SHA || process.env.GIT_COMMIT_SHA || process.env.NEXT_PUBLIC_GIT_SHA;
+}
+
+function resolveBuildTime() {
+  return process.env.BUILD_TIMESTAMP || process.env.VERCEL_BUILD_TIMESTAMP;
+}
+
+function compact<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(Object.entries(value).filter(([, entryValue]) => entryValue !== undefined && entryValue !== null)) as T;
+}
+
+export function collectVersionPayload() {
+  return compact({
+    service: serviceConfig.SERVICE_ID,
+    name: serviceConfig.SERVICE_NAME,
+    version: packageJson.version,
+    environment: appConfig.env,
+    gitCommit: resolveGitCommit(),
+    buildTime: resolveBuildTime()
+  });
+}
+
+export function collectHealthPayload() {
+  return {
+    ...collectVersionPayload(),
+    status: 'ok' as const,
+    timestamp: new Date().toISOString(),
+    uptime: Math.round(process.uptime() * 1000) / 1000,
+    startedAt: new Date(startedAt).toISOString()
+  };
+}
+
+export const identityHeaders = compact({
+  'X-Agent-ID': process.env.NEXT_PUBLIC_SERVICE_ID || 'blackroad-os-web',
+  'X-Service-ID': serviceConfig.SERVICE_ID,
+  'X-Service-Name': serviceConfig.SERVICE_NAME,
+  'X-PS-SHA∞': process.env.PS_SHA_INFINITY
+});
+
+export type VersionPayload = ReturnType<typeof collectVersionPayload>;
+export type HealthPayload = ReturnType<typeof collectHealthPayload>;

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -15,9 +15,8 @@ export const NAV_LINKS = [
   { href: '/agents', label: 'Agents' },
   { href: '/about', label: 'About' },
   { href: '/company', label: 'Company' },
-  { href: '/contact', label: 'Contact' }
-  { href: '/', label: 'Product', external: false },
-  { href: '/stack', label: 'Stack', external: false },
+  { href: '/contact', label: 'Contact' },
+  { href: '/stack', label: 'Stack' },
   { href: DOCS_URL, label: 'Docs', external: true },
   { href: PRISM_URL, label: 'Prism Console', external: true },
   { href: CONTACT_URL, label: 'Contact', external: true }


### PR DESCRIPTION
## Summary
- add observability helper to standardize version and health payloads with identity headers
- update /health and /version responses (and API re-export) to include environment, timestamps, and optional git/build info
- clean up navigation link definitions to remove duplicates

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923e28de3c08329bd3a71207a6271df)