### PR TITLE
chore(ci): pin checkout & setup-node actions to full SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@f43a3398dc5d8737c2dbc7bf8ad6b50918d7a3d4
+      - uses: actions/setup-node@b829d2ab59ffb3738572edf3c6dbd9bfebc477f1
         with:
           node-version: 18
           cache: 'pnpm'

--- a/.github/workflows/web-deploy.yaml
+++ b/.github/workflows/web-deploy.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@f43a3398dc5d8737c2dbc7bf8ad6b50918d7a3d4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@b829d2ab59ffb3738572edf3c6dbd9bfebc477f1
         with:
           node-version: 18
           cache: npm


### PR DESCRIPTION
## Summary
- pin `actions/checkout` and `actions/setup-node` to full commit SHAs in CI and deploy workflows

## Testing
- not run (workflow reference change only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692643d264188329816c87ef4644a548)