### PR TITLE
Add test runner to handle filtered test args

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "serve -s out -l ${PORT:-3000}",
     "lint": "next lint",
-    "test": "vitest run --passWithNoTests && playwright test",
+    "test": "tsx scripts/run-tests.ts",
     "postbuild": "tsx scripts/postbuild.ts",
     "typecheck": "tsc --noEmit",
     "format": "prettier --check ."

--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -1,0 +1,44 @@
+import { spawnSync } from 'node:child_process';
+
+function stripUnsupportedPlaywrightArgs(args: string[]): string[] {
+  const filtered: string[] = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+
+    if (arg === '--filter' || arg === '-f') {
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--filter=') || arg.startsWith('-f=')) {
+      continue;
+    }
+
+    filtered.push(arg);
+  }
+
+  return filtered;
+}
+
+function run(command: string, args: string[]) {
+  const result = spawnSync(command, args, { stdio: 'inherit' });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  return result.status ?? 1;
+}
+
+const cliArgs = process.argv.slice(2);
+const playwrightArgs = stripUnsupportedPlaywrightArgs(cliArgs);
+
+const vitestStatus = run('pnpm', ['vitest', 'run', '--passWithNoTests', ...cliArgs]);
+
+if (vitestStatus !== 0) {
+  process.exit(vitestStatus);
+}
+
+const playwrightStatus = run('pnpm', ['playwright', 'test', ...playwrightArgs]);
+process.exit(playwrightStatus);


### PR DESCRIPTION
## Summary
- replace the test script with a TSX helper that runs Vitest and Playwright sequentially
- strip unsupported filter flags from Playwright to allow filtered Vitest runs without errors

## Testing
- pnpm test -- --filter hero.spec.ts *(fails: Playwright browsers not installed in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a6ed7bc7c832989faf8fd4f9b1220)